### PR TITLE
Spring 2026/students/dza68

### DIFF
--- a/src/app/(app)/instructor/page.tsx
+++ b/src/app/(app)/instructor/page.tsx
@@ -1,8 +1,11 @@
+import { InstructorToolsPage } from "@/fe/instructor/page";
+import { ScrollbarHider } from "@/fe/shared";
+
 export default function InstructorPage() {
   return (
-    <div>
-      <h1>Instructor</h1>
-      <p>TODO: Implement instructor page</p>
-    </div>
+    <>
+      <ScrollbarHider />
+      <InstructorToolsPage />
+    </>
   );
 }

--- a/src/fe/instructor/components/ActionCard.tsx
+++ b/src/fe/instructor/components/ActionCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import BarChartOutlinedIcon from "@mui/icons-material/BarChartOutlined";
+import CreateOutlinedIcon from "@mui/icons-material/CreateOutlined";
+import EmojiEventsOutlinedIcon from "@mui/icons-material/EmojiEventsOutlined";
+import type { InstructorAction } from "../data";
+import styles from "../styles/InstructorToolsPage.module.css";
+
+const iconMap = {
+  primary: BarChartOutlinedIcon,
+  secondary: CreateOutlinedIcon,
+  accent: EmojiEventsOutlinedIcon,
+} as const;
+
+const toneClassMap = {
+  primary: styles.actionIconPrimary,
+  secondary: styles.actionIconSecondary,
+  accent: styles.actionIconAccent,
+} as const;
+
+interface ActionCardProps {
+  action: InstructorAction;
+}
+
+export default function ActionCard({ action }: ActionCardProps) {
+  const Icon = iconMap[action.tone];
+
+  return (
+    <button className={styles.actionCard} type="button">
+      <div className={`${styles.actionIcon} ${toneClassMap[action.tone]}`}>
+        <Icon fontSize="small" />
+      </div>
+      <h3 className={styles.actionTitle}>{action.title}</h3>
+      <p className={styles.actionDescription}>{action.description}</p>
+    </button>
+  );
+}

--- a/src/fe/instructor/components/ActivityItem.tsx
+++ b/src/fe/instructor/components/ActivityItem.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import TrendingUpOutlinedIcon from "@mui/icons-material/TrendingUpOutlined";
+import GroupAddOutlinedIcon from "@mui/icons-material/GroupAddOutlined";
+import type { ActivityItem as ActivityItemType } from "../data";
+import styles from "../styles/InstructorToolsPage.module.css";
+
+const iconMap = {
+  success: DescriptionOutlinedIcon,
+  info: TrendingUpOutlinedIcon,
+  highlight: GroupAddOutlinedIcon,
+} as const;
+
+const toneClassMap = {
+  success: styles.activityIconSuccess,
+  info: styles.activityIconInfo,
+  highlight: styles.activityIconHighlight,
+} as const;
+
+interface ActivityItemProps {
+  item: ActivityItemType;
+}
+
+export default function ActivityItem({ item }: ActivityItemProps) {
+  const Icon = iconMap[item.tone];
+
+  return (
+    <div className={styles.activityItem}>
+      <div className={`${styles.activityIcon} ${toneClassMap[item.tone]}`}>
+        <Icon fontSize="small" />
+      </div>
+      <div className={styles.activityText}>
+        <p className={styles.activityDescription}>{item.description}</p>
+        <p className={styles.activityTimestamp}>{item.timestamp}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/fe/instructor/components/InstructorToolsPage.tsx
+++ b/src/fe/instructor/components/InstructorToolsPage.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  instructorActions,
+  overviewStats,
+  recentActivity,
+} from "../data";
+import ActionCard from "./ActionCard";
+import OverviewCard from "./OverviewCard";
+import ActivityItem from "./ActivityItem";
+import styles from "../styles/InstructorToolsPage.module.css";
+
+export default function InstructorToolsPage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Instructor Tools</h1>
+        <p className={styles.subtitle}>
+          Manage your courses, create problems, and track student progress
+        </p>
+      </header>
+
+      <section className={styles.actionGrid}>
+        {instructorActions.map((action) => (
+          <ActionCard key={action.id} action={action} />
+        ))}
+      </section>
+
+      <section className={styles.sectionBlock}>
+        <h2 className={styles.sectionTitle}>Quick Overview</h2>
+        <div className={styles.overviewGrid}>
+          {overviewStats.map((stat) => (
+            <OverviewCard key={stat.id} stat={stat} />
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.sectionBlock}>
+        <h2 className={styles.sectionTitle}>Recent Activity</h2>
+        <div className={styles.activityList}>
+          {recentActivity.map((item) => (
+            <ActivityItem key={item.id} item={item} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/fe/instructor/components/OverviewCard.tsx
+++ b/src/fe/instructor/components/OverviewCard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
+import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
+import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
+import type { OverviewStat } from "../data";
+import styles from "../styles/InstructorToolsPage.module.css";
+
+const iconMap = {
+  courses: MenuBookOutlinedIcon,
+  students: GroupOutlinedIcon,
+  problems: FactCheckOutlinedIcon,
+} as const;
+
+interface OverviewCardProps {
+  stat: OverviewStat;
+}
+
+export default function OverviewCard({ stat }: OverviewCardProps) {
+  const Icon = iconMap[stat.tone];
+
+  return (
+    <div className={styles.overviewCard}>
+      <div className={styles.overviewHeader}>
+        <p className={styles.overviewLabel}>{stat.label}</p>
+        <Icon className={styles.overviewIcon} />
+      </div>
+      <p className={styles.overviewValue}>{stat.value}</p>
+      <p className={styles.overviewCaption}>{stat.caption}</p>
+    </div>
+  );
+}

--- a/src/fe/instructor/components/index.ts
+++ b/src/fe/instructor/components/index.ts
@@ -1,0 +1,1 @@
+export { default as InstructorToolsPage } from "./InstructorToolsPage";

--- a/src/fe/instructor/data/actions.ts
+++ b/src/fe/instructor/data/actions.ts
@@ -1,0 +1,32 @@
+export type InstructorActionTone = "primary" | "secondary" | "accent";
+
+export interface InstructorAction {
+  id: string;
+  title: string;
+  description: string;
+  tone: InstructorActionTone;
+}
+
+export const instructorActions: InstructorAction[] = [
+  {
+    id: "analytics",
+    title: "Analytics Dashboard",
+    description:
+      "View student performance, submission statistics, and course analytics",
+    tone: "primary",
+  },
+  {
+    id: "create-problem",
+    title: "Create Problem",
+    description:
+      "Author new programming problems with test cases and solutions",
+    tone: "secondary",
+  },
+  {
+    id: "create-contest",
+    title: "Create Contest",
+    description:
+      "Set up a new contest with multiple problems and time constraints",
+    tone: "accent",
+  },
+];

--- a/src/fe/instructor/data/index.ts
+++ b/src/fe/instructor/data/index.ts
@@ -1,0 +1,3 @@
+export * from "./actions";
+export * from "./overview";
+export * from "./recentActivity";

--- a/src/fe/instructor/data/overview.ts
+++ b/src/fe/instructor/data/overview.ts
@@ -1,0 +1,33 @@
+export type OverviewTone = "courses" | "students" | "problems";
+
+export interface OverviewStat {
+  id: string;
+  label: string;
+  value: string;
+  caption: string;
+  tone: OverviewTone;
+}
+
+export const overviewStats: OverviewStat[] = [
+  {
+    id: "active-courses",
+    label: "Active Courses",
+    value: "3",
+    caption: "2 ongoing, 1 upcoming",
+    tone: "courses",
+  },
+  {
+    id: "total-students",
+    label: "Total Students",
+    value: "147",
+    caption: "Across all courses",
+    tone: "students",
+  },
+  {
+    id: "problems-created",
+    label: "Problems Created",
+    value: "28",
+    caption: "12 this semester",
+    tone: "problems",
+  },
+];

--- a/src/fe/instructor/data/recentActivity.ts
+++ b/src/fe/instructor/data/recentActivity.ts
@@ -1,0 +1,29 @@
+export type ActivityTone = "success" | "info" | "highlight";
+
+export interface ActivityItem {
+  id: string;
+  description: string;
+  timestamp: string;
+  tone: ActivityTone;
+}
+
+export const recentActivity: ActivityItem[] = [
+  {
+    id: "activity-1",
+    description: 'New problem "Binary Search Tree" published',
+    timestamp: "2 hours ago",
+    tone: "success",
+  },
+  {
+    id: "activity-2",
+    description: "CS 201 avg submission rate increased by 15%",
+    timestamp: "1 day ago",
+    tone: "info",
+  },
+  {
+    id: "activity-3",
+    description: "8 new students enrolled in CS 301",
+    timestamp: "3 days ago",
+    tone: "highlight",
+  },
+];

--- a/src/fe/instructor/page/index.ts
+++ b/src/fe/instructor/page/index.ts
@@ -1,0 +1,1 @@
+export { default as InstructorToolsPage } from "../components/InstructorToolsPage";

--- a/src/fe/instructor/styles/InstructorToolsPage.module.css
+++ b/src/fe/instructor/styles/InstructorToolsPage.module.css
@@ -1,0 +1,277 @@
+:global(:root) {
+  --color-page-bg: #f9fafb;
+  --color-surface: #ffffff;
+  --color-border: #e5e7eb;
+  --color-text-primary: #101828;
+  --color-text-secondary: #4a5565;
+  --color-text-tertiary: #6a7282;
+  --color-icon-muted: #98a2b3;
+  --color-accent-blue-bg: #eff6ff;
+  --color-accent-blue: #2563eb;
+  --color-accent-purple-bg: #faf5ff;
+  --color-accent-purple: #9333ea;
+  --color-accent-orange-bg: #fff7ed;
+  --color-accent-orange: #f97316;
+  --color-accent-green-bg: #f0fdf4;
+  --color-accent-green: #00a63e;
+  --color-focus: #e7000b;
+}
+
+.page {
+  background-color: var(--color-page-bg);
+  margin: -32px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  font-family: Inter, sans-serif;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.title {
+  font-size: 24px;
+  line-height: 36px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  letter-spacing: 0.0703px;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  letter-spacing: -0.3125px;
+  margin: 0;
+}
+
+.sectionTitle {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  color: var(--color-text-primary);
+  letter-spacing: -0.3125px;
+  margin: 0;
+}
+
+.actionGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.actionCard {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  height: 186px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  appearance: none;
+}
+
+.actionCard:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.actionIcon {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.actionIconPrimary {
+  background-color: var(--color-accent-blue-bg);
+  color: var(--color-accent-blue);
+}
+
+.actionIconSecondary {
+  background-color: var(--color-accent-purple-bg);
+  color: var(--color-accent-purple);
+}
+
+.actionIconAccent {
+  background-color: var(--color-accent-orange-bg);
+  color: var(--color-accent-orange);
+}
+
+.actionTitle {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  color: var(--color-text-primary);
+  letter-spacing: -0.3125px;
+  margin: 0;
+}
+
+.actionDescription {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  letter-spacing: -0.1504px;
+  margin: 0;
+}
+
+.overviewGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.overviewCard {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  height: 134px;
+  padding: 25px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.overviewHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.overviewLabel {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  letter-spacing: -0.1504px;
+  margin: 0;
+}
+
+.overviewValue {
+  font-size: 30px;
+  line-height: 36px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: 0.3955px;
+  margin: 0;
+}
+
+.overviewCaption {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  margin: 0;
+}
+
+.overviewIcon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-icon-muted);
+}
+
+.activityList {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.activityItem {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.activityItem:last-child {
+  border-bottom: none;
+}
+
+.activityIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.activityIconSuccess {
+  background-color: var(--color-accent-green-bg);
+  color: var(--color-accent-green);
+}
+
+.activityIconInfo {
+  background-color: var(--color-accent-blue-bg);
+  color: var(--color-accent-blue);
+}
+
+.activityIconHighlight {
+  background-color: var(--color-accent-purple-bg);
+  color: var(--color-accent-purple);
+}
+
+.activityText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.activityDescription {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: var(--color-text-primary);
+  letter-spacing: -0.1504px;
+  margin: 0;
+}
+
+.activityTimestamp {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  margin: 0;
+}
+
+@media (max-width: 1024px) {
+  .actionGrid,
+  .overviewGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    margin: -32px -16px;
+    padding: 32px 16px;
+  }
+
+  .actionGrid,
+  .overviewGrid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
Implemented the Instructor Tools page to match the Figma layout with action cards, quick overview stats, and recent activity list. Added invisible scrollbar behavior for the instructor page.

## Files Changed (<= 20)
- `src/app/(app)/instructor/page.tsx`
- `src/fe/instructor/components/InstructorToolsPage.tsx`
- `src/fe/instructor/components/ActionCard.tsx`
- `src/fe/instructor/components/OverviewCard.tsx`
- `src/fe/instructor/components/ActivityItem.tsx`
- `src/fe/instructor/components/index.ts`
- `src/fe/instructor/data/actions.ts`
- `src/fe/instructor/data/overview.ts`
- `src/fe/instructor/data/recentActivity.ts`
- `src/fe/instructor/data/index.ts`
- `src/fe/instructor/page/index.ts`
- `src/fe/instructor/styles/InstructorToolsPage.module.css`

## Features Added
- Instructor tools overview with action cards, key stats, and recent activity list.

## Components
- `src/fe/instructor/components/InstructorToolsPage.tsx`
- `src/fe/instructor/components/ActionCard.tsx`
- `src/fe/instructor/components/OverviewCard.tsx`
- `src/fe/instructor/components/ActivityItem.tsx`

## Data
- `src/fe/instructor/data/actions.ts`
- `src/fe/instructor/data/overview.ts`
- `src/fe/instructor/data/recentActivity.ts`

## Data & Utilities
- None.

## Styles
- `src/fe/instructor/styles/InstructorToolsPage.module.css`

## UI Changes (screenshots, frontend only)
- Before: NO
- After: 
<img width="1312" height="693" alt="Screenshot 2026-01-30 at 13 30 57" src="https://github.com/user-attachments/assets/fd393bb8-f51f-49c2-b52d-b7cef7d5592b" />

## QA
`npm run lint`
