### PR TITLE
chore: align admin role types

### DIFF
--- a/src/fe/admin/data/users.ts
+++ b/src/fe/admin/data/users.ts
@@ -1,4 +1,6 @@
-export type AdminUserRole = "student" | "instructor" | "admin";
+import type { Role } from "@/lib/authz";
+
+export type AdminUserRole = Role;
 
 export interface AdminUserRecord {
   id: string;

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -4,7 +4,7 @@ const ROLE_LEVEL: Record<Role, number> = {
   student: 0,
   instructor: 1,
   admin: 2,
-}
+};
 
 export function isRole(value: unknown): value is Role {
   return value === "student" || value === "instructor" || value === "admin";


### PR DESCRIPTION
## Summary
Follow up on review feedback from the TA-access cleanup by aligning the admin mock user role type with the shared app `Role` type and adding the missing semicolon in the shared auth role level map.

## Files Changed (<= 20)
- `src/lib/authz.ts`
- `src/fe/admin/data/users.ts`

## Data & Utilities
- Reuse the shared `Role` type for `AdminUserRole`
- Add the missing trailing semicolon to `ROLE_LEVEL`

## QA
- Ran targeted `eslint` on `src/lib/authz.ts` and `src/fe/admin/data/users.ts`
- Verified no behavior change is introduced beyond the type alignment and style cleanup
