### PR TITLE
feat: add instructor analysis data pipeline

### DIFF
--- a/src/lib/trpc/types/instructorAnalysis.ts
+++ b/src/lib/trpc/types/instructorAnalysis.ts
@@ -1,0 +1,66 @@
+export type SnapshotPreference = "latest" | "preliminary" | "final";
+export type SnapshotType = "PRELIMINARY_5M" | "FINAL_15M";
+export type SnapshotRunStatus = "QUEUED" | "RUNNING" | "DONE" | "FAILED" | "NOT_READY";
+
+export interface InstructorAnalysisFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface InstructorAnalysisContestGroupMetric {
+  groupName: "A" | "B" | "C";
+  solveRate: number;
+  meanSolveTimeSec: number | null;
+  medianSolveTimeSec: number | null;
+  attemptsToSolveMean: number | null;
+}
+
+export interface InstructorAnalysisProblemStudentMetric {
+  studentId: string;
+  studentName: string;
+  groupName: "A" | "B" | "C" | null;
+  timeToFirstSubmissionSec: number | null;
+  timeToFirstCorrectSec: number | null;
+  postHintSolveProbability: number | null;
+  attemptsBeforeHint: number | null;
+  attemptsAfterHint: number | null;
+  timeToSolveAfterHintSec: number | null;
+}
+
+export interface InstructorAnalysisResponse {
+  role: "instructor";
+  filters: {
+    contests: InstructorAnalysisFilterOption[];
+    problems: InstructorAnalysisFilterOption[];
+    snapshotPreferences: Array<{
+      value: SnapshotPreference;
+      label: string;
+    }>;
+  };
+  selection: {
+    contestId: string | null;
+    problemId: string | null;
+    snapshotPreference: SnapshotPreference;
+  };
+  contest: {
+    id: string | null;
+    title: string | null;
+    startsAt: string | null;
+    endsAt: string | null;
+    status: "Draft" | "Upcoming" | "Active" | "Ended" | null;
+  };
+  snapshot: {
+    requestedPreference: SnapshotPreference;
+    resolvedType: SnapshotType | null;
+    status: SnapshotRunStatus;
+    watermark: string | null;
+    computedAt: string | null;
+    message: string;
+  };
+  contestGroupMetrics: {
+    rows: InstructorAnalysisContestGroupMetric[];
+  };
+  problemStudentMetrics: {
+    rows: InstructorAnalysisProblemStudentMetric[];
+  };
+}

--- a/src/server/instructorAnalysis/metrics.ts
+++ b/src/server/instructorAnalysis/metrics.ts
@@ -1,0 +1,249 @@
+import type { ExperimentGroup } from "@prisma/client";
+import type { SnapshotType } from "@/lib/trpc/types/instructorAnalysis";
+
+interface ContestMetricInput {
+  id: string;
+  startsAt: Date;
+  contestProblems: Array<{
+    problem: {
+      id: string;
+    };
+  }>;
+  experimentGroups: Array<{
+    groupName: ExperimentGroup;
+  }>;
+  participations: Array<{
+    userId: string;
+    role: string;
+    experimentGroup: ExperimentGroup | null;
+    user: {
+      firstName: string;
+      lastName: string;
+    };
+  }>;
+  contestProblemSessions: Array<{
+    userId: string;
+    problemId: string;
+    startedAt: Date;
+    firstSubmitAt: Date | null;
+    hintTriggeredAt: Date | null;
+    solvedAt: Date | null;
+    solved: boolean;
+  }>;
+  submissions: Array<{
+    userId: string;
+    problemId: string;
+    createdAt: Date;
+  }>;
+}
+
+export interface ComputedContestGroupMetricsRow {
+  contestId: string;
+  groupName: ExperimentGroup;
+  snapshotType: SnapshotType;
+  watermark: Date;
+  solveRate: number;
+  meanSolveTimeSec: number | null;
+  medianSolveTimeSec: number | null;
+  attemptsToSolveMean: number | null;
+}
+
+export interface ComputedProblemStudentMetricsRow {
+  contestId: string;
+  problemId: string;
+  studentId: string;
+  snapshotType: SnapshotType;
+  watermark: Date;
+  groupName: ExperimentGroup | null;
+  timeToFirstSubmissionSec: number | null;
+  timeToFirstCorrectSec: number | null;
+  postHintSolveProbability: number | null;
+  attemptsBeforeHint: number | null;
+  attemptsAfterHint: number | null;
+  timeToSolveAfterHintSec: number | null;
+}
+
+function toSeconds(start: Date, end: Date | null): number | null {
+  if (!end) {
+    return null;
+  }
+
+  const diff = Math.round((end.getTime() - start.getTime()) / 1000);
+  return diff >= 0 ? diff : null;
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+
+  return Math.round((sorted[middle - 1] + sorted[middle]) / 2);
+}
+
+function buildSubmissionMap(contest: ContestMetricInput, watermark: Date): Map<string, Date[]> {
+  const map = new Map<string, Date[]>();
+
+  contest.submissions.forEach((submission) => {
+    if (submission.createdAt.getTime() > watermark.getTime()) {
+      return;
+    }
+
+    const key = `${submission.userId}:${submission.problemId}`;
+    const current = map.get(key) ?? [];
+    current.push(submission.createdAt);
+    map.set(key, current);
+  });
+
+  map.forEach((entries, key) => {
+    map.set(
+      key,
+      entries.sort((left, right) => left.getTime() - right.getTime()),
+    );
+  });
+
+  return map;
+}
+
+export function computeInstructorMetricsSnapshot(
+  contest: ContestMetricInput,
+  snapshotType: SnapshotType,
+  watermark: Date,
+): {
+  contestGroupRows: ComputedContestGroupMetricsRow[];
+  problemStudentRows: ComputedProblemStudentMetricsRow[];
+} {
+  const contestantParticipations = contest.participations.filter(
+    (participation) => participation.role === "contestant",
+  );
+  const problemIds = contest.contestProblems.map((entry) => entry.problem.id);
+  const submissionMap = buildSubmissionMap(contest, watermark);
+  const sessionsByUserProblem = new Map(
+    contest.contestProblemSessions
+      .filter((session) => session.startedAt.getTime() <= watermark.getTime())
+      .map((session) => [`${session.userId}:${session.problemId}`, session] as const),
+  );
+  const groups = Array.from(
+    new Set<ExperimentGroup>([
+      ...contest.experimentGroups.map((group) => group.groupName),
+      ...contestantParticipations
+        .map((participation) => participation.experimentGroup)
+        .filter((group): group is ExperimentGroup => group !== null),
+    ]),
+  ).sort();
+
+  const contestGroupRows = groups.map((groupName) => {
+    const groupParticipants = contestantParticipations.filter(
+      (participation) => participation.experimentGroup === groupName,
+    );
+    const totalExpected = groupParticipants.length * problemIds.length;
+    let solvedCount = 0;
+    const solveDurations: number[] = [];
+    const attemptsToSolve: number[] = [];
+
+    groupParticipants.forEach((participation) => {
+      problemIds.forEach((problemId) => {
+        const session = sessionsByUserProblem.get(`${participation.userId}:${problemId}`);
+        const solvedAt =
+          session?.solved && session.solvedAt && session.solvedAt.getTime() <= watermark.getTime()
+            ? session.solvedAt
+            : null;
+
+        if (!session || !solvedAt) {
+          return;
+        }
+
+        solvedCount += 1;
+        const solveSeconds = toSeconds(session.startedAt, solvedAt);
+        if (solveSeconds !== null) {
+          solveDurations.push(solveSeconds);
+        }
+
+        const submissions = submissionMap.get(`${participation.userId}:${problemId}`) ?? [];
+        attemptsToSolve.push(
+          submissions.filter((submittedAt) => submittedAt.getTime() <= solvedAt.getTime()).length,
+        );
+      });
+    });
+
+    const meanSolveTimeSec = average(solveDurations);
+    const attemptsToSolveMean = average(attemptsToSolve);
+
+    return {
+      contestId: contest.id,
+      groupName,
+      snapshotType,
+      watermark,
+      solveRate: totalExpected === 0 ? 0 : Math.round((solvedCount / totalExpected) * 1000) / 10,
+      meanSolveTimeSec: meanSolveTimeSec === null ? null : Math.round(meanSolveTimeSec),
+      medianSolveTimeSec: median(solveDurations),
+      attemptsToSolveMean:
+        attemptsToSolveMean === null ? null : Math.round(attemptsToSolveMean * 10) / 10,
+    };
+  });
+
+  const problemStudentRows = contest.contestProblems.flatMap((entry) =>
+    contestantParticipations
+      .slice()
+      .sort((left, right) => {
+        const leftName = `${left.user.firstName} ${left.user.lastName}`;
+        const rightName = `${right.user.firstName} ${right.user.lastName}`;
+        return leftName.localeCompare(rightName);
+      })
+      .map((participation) => {
+        const session = sessionsByUserProblem.get(`${participation.userId}:${entry.problem.id}`);
+        const submissions = submissionMap.get(`${participation.userId}:${entry.problem.id}`) ?? [];
+        const solvedAt =
+          session?.solved && session.solvedAt && session.solvedAt.getTime() <= watermark.getTime()
+            ? session.solvedAt
+            : null;
+        const hintTriggeredAt =
+          session?.hintTriggeredAt && session.hintTriggeredAt.getTime() <= watermark.getTime()
+            ? session.hintTriggeredAt
+            : null;
+        const anchorStart = session?.startedAt ?? contest.startsAt;
+        const firstSubmissionAt =
+          session?.firstSubmitAt && session.firstSubmitAt.getTime() <= watermark.getTime()
+            ? session.firstSubmitAt
+            : submissions[0] ?? null;
+
+        return {
+          contestId: contest.id,
+          problemId: entry.problem.id,
+          studentId: participation.userId,
+          snapshotType,
+          watermark,
+          groupName: participation.experimentGroup,
+          timeToFirstSubmissionSec: toSeconds(anchorStart, firstSubmissionAt),
+          timeToFirstCorrectSec: toSeconds(anchorStart, solvedAt),
+          postHintSolveProbability: hintTriggeredAt ? (solvedAt ? 100 : 0) : null,
+          attemptsBeforeHint: hintTriggeredAt
+            ? submissions.filter((submittedAt) => submittedAt.getTime() <= hintTriggeredAt.getTime()).length
+            : null,
+          attemptsAfterHint: hintTriggeredAt
+            ? submissions.filter((submittedAt) => submittedAt.getTime() > hintTriggeredAt.getTime()).length
+            : null,
+          timeToSolveAfterHintSec:
+            hintTriggeredAt && solvedAt ? toSeconds(hintTriggeredAt, solvedAt) : null,
+        };
+      }),
+  );
+
+  return {
+    contestGroupRows,
+    problemStudentRows,
+  };
+}

--- a/src/server/instructorAnalysis/repository.ts
+++ b/src/server/instructorAnalysis/repository.ts
@@ -1,0 +1,370 @@
+import type { ExperimentGroup } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  SnapshotPreference,
+  SnapshotRunStatus,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+import { computeInstructorMetricsSnapshot } from "./metrics";
+
+type PrismaClient = typeof prisma;
+
+export interface InstructorAnalysisSnapshot {
+  instructor: {
+    id: string;
+    computingId: string;
+  };
+  contests: Array<{
+    id: string;
+    name: string;
+    status: "DRAFT" | "UPCOMING" | "ACTIVE" | "ENDED";
+    startsAt: Date;
+    endsAt: Date | null;
+    contestProblems: Array<{
+      problem: {
+        id: string;
+        code: string;
+        title: string;
+      };
+    }>;
+  }>;
+  selectedContestId: string | null;
+  selectedProblemId: string | null;
+  snapshot: {
+    requestedPreference: SnapshotPreference;
+    resolvedType: SnapshotType | null;
+    status: SnapshotRunStatus;
+    watermark: Date | null;
+    computedAt: Date | null;
+    message: string;
+  };
+  contestGroupRows: Array<{
+    groupName: ExperimentGroup;
+    solveRate: number;
+    meanSolveTimeSec: number | null;
+    medianSolveTimeSec: number | null;
+    attemptsToSolveMean: number | null;
+  }>;
+  problemStudentRows: Array<{
+    studentId: string;
+    studentName: string;
+    groupName: ExperimentGroup | null;
+    timeToFirstSubmissionSec: number | null;
+    timeToFirstCorrectSec: number | null;
+    postHintSolveProbability: number | null;
+    attemptsBeforeHint: number | null;
+    attemptsAfterHint: number | null;
+    timeToSolveAfterHintSec: number | null;
+  }>;
+}
+
+function resolveRequestedSnapshot(
+  endsAt: Date | null,
+  requestedPreference: SnapshotPreference,
+): {
+  resolvedType: SnapshotType | null;
+  watermark: Date | null;
+  message: string;
+} {
+  if (!endsAt) {
+    return {
+      resolvedType: null,
+      watermark: null,
+      message: "Snapshot scheduling starts once the contest has an end time.",
+    };
+  }
+
+  const preliminary = new Date(endsAt.getTime() + 5 * 60 * 1000);
+  const final = new Date(endsAt.getTime() + 15 * 60 * 1000);
+  const now = new Date();
+
+  if (requestedPreference === "preliminary") {
+    if (now.getTime() < preliminary.getTime()) {
+      return {
+        resolvedType: null,
+        watermark: preliminary,
+        message: "Preliminary snapshot becomes available 5 minutes after contest end.",
+      };
+    }
+
+    return {
+      resolvedType: "PRELIMINARY_5M",
+      watermark: preliminary,
+      message: "Showing the preliminary (+5m) snapshot.",
+    };
+  }
+
+  if (requestedPreference === "final") {
+    if (now.getTime() < final.getTime()) {
+      return {
+        resolvedType: null,
+        watermark: final,
+        message: "Final snapshot becomes available 15 minutes after contest end.",
+      };
+    }
+
+    return {
+      resolvedType: "FINAL_15M",
+      watermark: final,
+      message: "Showing the final (+15m) snapshot.",
+    };
+  }
+
+  if (now.getTime() >= final.getTime()) {
+    return {
+      resolvedType: "FINAL_15M",
+      watermark: final,
+      message: "Showing the latest available snapshot (final +15m).",
+    };
+  }
+
+  if (now.getTime() >= preliminary.getTime()) {
+    return {
+      resolvedType: "PRELIMINARY_5M",
+      watermark: preliminary,
+      message: "Showing the latest available snapshot (preliminary +5m).",
+    };
+  }
+
+  return {
+    resolvedType: null,
+    watermark: preliminary,
+    message: "No snapshot is ready yet. Preliminary metrics unlock 5 minutes after contest end.",
+  };
+}
+
+async function computeSnapshotRows(
+  client: PrismaClient,
+  contestId: string,
+  selectedProblemId: string | null,
+  snapshotType: SnapshotType,
+  watermark: Date,
+): Promise<{
+  contestGroupRows: InstructorAnalysisSnapshot["contestGroupRows"];
+  problemStudentRows: InstructorAnalysisSnapshot["problemStudentRows"];
+}> {
+  const contest = await client.contest.findUnique({
+    where: { id: contestId },
+    select: {
+      id: true,
+      startsAt: true,
+      contestProblems: {
+        orderBy: { ordering: "asc" },
+        select: {
+          problem: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+      experimentGroups: {
+        select: {
+          groupName: true,
+        },
+      },
+      participations: {
+        select: {
+          userId: true,
+          role: true,
+          experimentGroup: true,
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+      },
+      contestProblemSessions: {
+        select: {
+          userId: true,
+          problemId: true,
+          startedAt: true,
+          firstSubmitAt: true,
+          hintTriggeredAt: true,
+          solvedAt: true,
+          solved: true,
+        },
+      },
+      submissions: {
+        select: {
+          userId: true,
+          problemId: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!contest) {
+    return {
+      contestGroupRows: [],
+      problemStudentRows: [],
+    };
+  }
+
+  const computed = computeInstructorMetricsSnapshot(contest, snapshotType, watermark);
+
+  return {
+    contestGroupRows: computed.contestGroupRows.map((row) => ({
+      groupName: row.groupName,
+      solveRate: row.solveRate,
+      meanSolveTimeSec: row.meanSolveTimeSec,
+      medianSolveTimeSec: row.medianSolveTimeSec,
+      attemptsToSolveMean: row.attemptsToSolveMean,
+    })),
+    problemStudentRows: computed.problemStudentRows
+      .filter((row) => !selectedProblemId || row.problemId === selectedProblemId)
+      .map((row) => {
+        const participation = contest.participations.find(
+          (entry) => entry.userId === row.studentId,
+        );
+
+        if (!participation) {
+          return null;
+        }
+
+        return {
+          studentId: row.studentId,
+          studentName: `${participation.user.firstName} ${participation.user.lastName}`,
+          groupName: row.groupName,
+          timeToFirstSubmissionSec: row.timeToFirstSubmissionSec,
+          timeToFirstCorrectSec: row.timeToFirstCorrectSec,
+          postHintSolveProbability: row.postHintSolveProbability,
+          attemptsBeforeHint: row.attemptsBeforeHint,
+          attemptsAfterHint: row.attemptsAfterHint,
+          timeToSolveAfterHintSec: row.timeToSolveAfterHintSec,
+        };
+      })
+      .filter((row): row is InstructorAnalysisSnapshot["problemStudentRows"][number] => row !== null)
+      .sort((left, right) => {
+        if (left.groupName !== right.groupName) {
+          return (left.groupName ?? "").localeCompare(right.groupName ?? "");
+        }
+
+        return left.studentName.localeCompare(right.studentName);
+      }),
+  };
+}
+
+export async function loadInstructorAnalysisSnapshot(
+  client: PrismaClient,
+  computingId: string,
+  input: {
+    contestId?: string;
+    problemId?: string;
+    snapshotPreference: SnapshotPreference;
+  },
+): Promise<InstructorAnalysisSnapshot | null> {
+  const instructor = await client.user.findUnique({
+    where: { computingId },
+    select: {
+      id: true,
+      computingId: true,
+    },
+  });
+
+  if (!instructor) {
+    return null;
+  }
+
+  const contests = await client.contest.findMany({
+    where: { instructorId: instructor.id },
+    orderBy: [{ startsAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      startsAt: true,
+      endsAt: true,
+      contestProblems: {
+        orderBy: { ordering: "asc" },
+        select: {
+          problem: {
+            select: {
+              id: true,
+              code: true,
+              title: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (contests.length === 0) {
+    return {
+      instructor,
+      contests: [],
+      selectedContestId: null,
+      selectedProblemId: null,
+      snapshot: {
+        requestedPreference: input.snapshotPreference,
+        resolvedType: null,
+        status: "NOT_READY",
+        watermark: null,
+        computedAt: null,
+        message: "No instructor contests are available yet.",
+      },
+      contestGroupRows: [],
+      problemStudentRows: [],
+    };
+  }
+
+  const selectedContest = contests.find((contest) => contest.id === input.contestId) ?? contests[0];
+  const selectedContestId = selectedContest.id;
+  const selectedProblemId =
+    selectedContest.contestProblems.find((entry) => entry.problem.id === input.problemId)?.problem.id ??
+    selectedContest.contestProblems[0]?.problem.id ??
+    null;
+
+  const snapshotResolution = resolveRequestedSnapshot(
+    selectedContest.endsAt,
+    input.snapshotPreference,
+  );
+
+  let runStatus: SnapshotRunStatus = "NOT_READY";
+  let computedAt: Date | null = null;
+  let contestGroupRows: InstructorAnalysisSnapshot["contestGroupRows"] = [];
+  let problemStudentRows: InstructorAnalysisSnapshot["problemStudentRows"] = [];
+
+  if (snapshotResolution.resolvedType && snapshotResolution.watermark) {
+    try {
+      const computed = await computeSnapshotRows(
+        client,
+        selectedContestId,
+        selectedProblemId,
+        snapshotResolution.resolvedType,
+        snapshotResolution.watermark,
+      );
+      runStatus = "DONE";
+      computedAt = new Date();
+      contestGroupRows = computed.contestGroupRows;
+      problemStudentRows = computed.problemStudentRows;
+    } catch (error) {
+      runStatus = "FAILED";
+      snapshotResolution.message =
+        error instanceof Error
+          ? `Snapshot computation failed: ${error.message}`
+          : "Snapshot computation failed.";
+    }
+  }
+
+  return {
+    instructor,
+    contests,
+    selectedContestId,
+    selectedProblemId,
+    snapshot: {
+      requestedPreference: input.snapshotPreference,
+      resolvedType: snapshotResolution.resolvedType,
+      status: runStatus,
+      watermark: snapshotResolution.watermark,
+      computedAt,
+      message: snapshotResolution.message,
+    },
+    contestGroupRows,
+    problemStudentRows,
+  };
+}

--- a/src/server/instructorAnalysis/serializer.ts
+++ b/src/server/instructorAnalysis/serializer.ts
@@ -1,0 +1,80 @@
+import type {
+  InstructorAnalysisResponse,
+  SnapshotPreference,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+import type { InstructorAnalysisSnapshot } from "./repository";
+
+function titleCaseContestStatus(
+  status: "DRAFT" | "UPCOMING" | "ACTIVE" | "ENDED",
+): "Draft" | "Upcoming" | "Active" | "Ended" {
+  switch (status) {
+    case "DRAFT":
+      return "Draft";
+    case "UPCOMING":
+      return "Upcoming";
+    case "ACTIVE":
+      return "Active";
+    case "ENDED":
+      return "Ended";
+  }
+}
+
+function snapshotPreferenceLabel(value: SnapshotPreference): string {
+  if (value === "latest") return "Latest Available";
+  if (value === "preliminary") return "Preliminary (+5m)";
+  return "Final (+15m)";
+}
+
+export function buildInstructorAnalysisResponse(
+  snapshot: InstructorAnalysisSnapshot,
+): InstructorAnalysisResponse {
+  const selectedContest =
+    snapshot.contests.find((contest) => contest.id === snapshot.selectedContestId) ?? null;
+
+  return {
+    role: "instructor",
+    filters: {
+      contests: snapshot.contests.map((contest) => ({
+        value: contest.id,
+        label: contest.name,
+      })),
+      problems: (selectedContest?.contestProblems ?? []).map((entry) => ({
+        value: entry.problem.id,
+        label: `${entry.problem.code} - ${entry.problem.title}`,
+      })),
+      snapshotPreferences: (["latest", "preliminary", "final"] as SnapshotPreference[]).map(
+        (value) => ({
+          value,
+          label: snapshotPreferenceLabel(value),
+        }),
+      ),
+    },
+    selection: {
+      contestId: snapshot.selectedContestId,
+      problemId: snapshot.selectedProblemId,
+      snapshotPreference: snapshot.snapshot.requestedPreference,
+    },
+    contest: {
+      id: selectedContest?.id ?? null,
+      title: selectedContest?.name ?? null,
+      startsAt: selectedContest?.startsAt.toISOString() ?? null,
+      endsAt: selectedContest?.endsAt?.toISOString() ?? null,
+      status: selectedContest ? titleCaseContestStatus(selectedContest.status) : null,
+    },
+    snapshot: {
+      requestedPreference: snapshot.snapshot.requestedPreference,
+      resolvedType: snapshot.snapshot.resolvedType as SnapshotType | null,
+      status: snapshot.snapshot.status,
+      watermark: snapshot.snapshot.watermark?.toISOString() ?? null,
+      computedAt: snapshot.snapshot.computedAt?.toISOString() ?? null,
+      message: snapshot.snapshot.message,
+    },
+    contestGroupMetrics: {
+      rows: snapshot.contestGroupRows,
+    },
+    problemStudentMetrics: {
+      rows: snapshot.problemStudentRows,
+    },
+  };
+}

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -2,6 +2,7 @@ import { router } from "../init";
 import { adminDashboardRouter } from "./adminDashboard";
 import { contestAuthoringRouter } from "./contestAuthoring";
 import { dashboardMetadataRouter } from "./dashboardMetadata";
+import { instructorAnalysisRouter } from "./instructorAnalysis";
 import { instructorManageContentRouter } from "./instructorManageContent";
 import { problemAuthoringRouter } from "./problemAuthoring";
 import { instructorDashboardRouter } from "./instructorDashboard";
@@ -14,6 +15,7 @@ export const appRouter = router({
   adminDashboard: adminDashboardRouter,
   dashboardMetadata: dashboardMetadataRouter,
   instructorDashboard: instructorDashboardRouter,
+  instructorAnalysis: instructorAnalysisRouter,
   contestAuthoring: contestAuthoringRouter,
   problemAuthoring: problemAuthoringRouter,
   instructorManageContent: instructorManageContentRouter,

--- a/src/server/trpc/routers/instructorAnalysis.ts
+++ b/src/server/trpc/routers/instructorAnalysis.ts
@@ -1,0 +1,32 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure, router } from "../init";
+import { loadInstructorAnalysisSnapshot } from "@/server/instructorAnalysis/repository";
+import { buildInstructorAnalysisResponse } from "@/server/instructorAnalysis/serializer";
+
+const instructorAnalysisInputSchema = z.object({
+  contestId: z.string().optional(),
+  problemId: z.string().optional(),
+  snapshotPreference: z.enum(["latest", "preliminary", "final"]).default("latest"),
+});
+
+export const instructorAnalysisRouter = router({
+  get: protectedProcedure
+    .input(instructorAnalysisInputSchema)
+    .query(async ({ ctx, input }) => {
+      if (ctx.user.role !== "instructor") {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
+
+      const snapshot = await loadInstructorAnalysisSnapshot(
+        ctx.prisma,
+        ctx.user.computingId,
+        input,
+      );
+      if (!snapshot) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Instructor not found" });
+      }
+
+      return buildInstructorAnalysisResponse(snapshot);
+    }),
+});


### PR DESCRIPTION
## Summary
Add the instructor analysis data pipeline by wiring a new instructor-only tRPC route, runtime snapshot computation, repository loading, serializer output, and shared tRPC response types for the research analytics flow.

## Files Changed (<= 20)
- `src/lib/trpc/types/instructorAnalysis.ts`
- `src/server/instructorAnalysis/metrics.ts`
- `src/server/instructorAnalysis/repository.ts`
- `src/server/instructorAnalysis/serializer.ts`
- `src/server/trpc/routers/instructorAnalysis.ts`
- `src/server/trpc/routers/index.ts`

## APIs
- `GET /api/trpc/instructorAnalysis.get`

## QA
- Ran targeted `eslint` on the new instructor analysis pipeline files
- Ran `npx tsc --noEmit`; remaining failure is an existing unrelated baseline issue in `tests/e2e/practice/practice-python-ai-judging.spec.ts`
- Verified instructor dev login succeeds locally
- Verified `/instructor` still returns `200`
- Verified `/instructor/research-analytics` still returns `200`
- Verified `instructorAnalysis.get` returns `200` for an instructor session
- Verified `/admin` and `/dashboard` still return `200` after the new router was wired in
