### PR TITLE
feat: add instructor analysis data pipeline and ui

### DIFF
--- a/src/fe/instructor/components/InstructorAnalysisContestMetricsCard.tsx
+++ b/src/fe/instructor/components/InstructorAnalysisContestMetricsCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Groups2OutlinedIcon from "@mui/icons-material/Groups2Outlined";
+import { Box, Typography } from "@mui/material";
+import type { InstructorAnalysisContestGroupMetricRow } from "@/lib/types/instructorAnalysis";
+import styles from "@/fe/instructor/styles/ResearchAnalyticsPage.module.css";
+
+interface InstructorAnalysisContestMetricsCardProps {
+  rows: InstructorAnalysisContestGroupMetricRow[];
+}
+
+export default function InstructorAnalysisContestMetricsCard({
+  rows,
+}: InstructorAnalysisContestMetricsCardProps) {
+  return (
+    <Box className={styles.card}>
+      <Box className={styles.cardHeader}>
+        <Box>
+          <Typography className={styles.cardEyebrow}>Contest View</Typography>
+          <Typography className={styles.cardTitle}>Contest Metrics by Group</Typography>
+          <Typography className={styles.cardDescription}>
+            Snapshot-backed group matrices for solve rate, solve time, and attempts.
+          </Typography>
+        </Box>
+      </Box>
+
+      {rows.length === 0 ? (
+        <Box className={styles.emptyState}>
+          <Groups2OutlinedIcon className={styles.emptyStateIcon} />
+          <Typography className={styles.emptyStateTitle}>No group metrics yet</Typography>
+          <Typography className={styles.emptyStateBody}>
+            Once a post-contest snapshot is available, this table will show per-group contest metrics.
+          </Typography>
+        </Box>
+      ) : (
+        <Box className={styles.tableWrap}>
+          <table className={styles.metricsTable}>
+            <thead>
+              <tr>
+                <th>Group</th>
+                <th>Solve Rate</th>
+                <th>Mean Solve Time</th>
+                <th>Median Solve Time</th>
+                <th>Attempts to Solve</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.groupLabel}>
+                  <td>{row.groupLabel}</td>
+                  <td>{row.solveRate}</td>
+                  <td>{row.meanSolveTime}</td>
+                  <td>{row.medianSolveTime}</td>
+                  <td>{row.attemptsToSolve}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/fe/instructor/components/InstructorAnalysisExportActions.tsx
+++ b/src/fe/instructor/components/InstructorAnalysisExportActions.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
+import { Box, Button } from "@mui/material";
+import type { InstructorAnalysisData } from "@/lib/types/instructorAnalysis";
+import {
+  exportInstructorAnalysisCsv,
+  exportInstructorAnalysisJson,
+} from "@/fe/instructor/services/instructorAnalysis.export";
+import styles from "@/fe/instructor/styles/ResearchAnalyticsPage.module.css";
+
+interface InstructorAnalysisExportActionsProps {
+  data: InstructorAnalysisData;
+  disabled?: boolean;
+}
+
+export default function InstructorAnalysisExportActions({
+  data,
+  disabled = false,
+}: InstructorAnalysisExportActionsProps) {
+  return (
+    <Box className={styles.exportActions}>
+      <Button
+        className={styles.exportButton}
+        variant="outlined"
+        startIcon={<FileDownloadOutlinedIcon />}
+        onClick={() => exportInstructorAnalysisJson(data)}
+        disabled={disabled}
+      >
+        Export JSON
+      </Button>
+      <Button
+        className={styles.exportButton}
+        variant="outlined"
+        startIcon={<FileDownloadOutlinedIcon />}
+        onClick={() => exportInstructorAnalysisCsv(data)}
+        disabled={disabled}
+      >
+        Export CSV
+      </Button>
+    </Box>
+  );
+}

--- a/src/fe/instructor/components/InstructorAnalysisProblemMetricsCard.tsx
+++ b/src/fe/instructor/components/InstructorAnalysisProblemMetricsCard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import TableViewRoundedIcon from "@mui/icons-material/TableViewRounded";
+import { Box, Typography } from "@mui/material";
+import type { InstructorAnalysisProblemStudentMetricRow } from "@/lib/types/instructorAnalysis";
+import styles from "@/fe/instructor/styles/ResearchAnalyticsPage.module.css";
+
+interface InstructorAnalysisProblemMetricsCardProps {
+  rows: InstructorAnalysisProblemStudentMetricRow[];
+}
+
+export default function InstructorAnalysisProblemMetricsCard({
+  rows,
+}: InstructorAnalysisProblemMetricsCardProps) {
+  return (
+    <Box className={styles.card}>
+      <Box className={styles.cardHeader}>
+        <Box>
+          <Typography className={styles.cardEyebrow}>Problem View</Typography>
+          <Typography className={styles.cardTitle}>Problem Metrics by Student</Typography>
+          <Typography className={styles.cardDescription}>
+            Student-level timing and hint behavior for the selected problem snapshot.
+          </Typography>
+        </Box>
+      </Box>
+
+      {rows.length === 0 ? (
+        <Box className={styles.emptyState}>
+          <TableViewRoundedIcon className={styles.emptyStateIcon} />
+          <Typography className={styles.emptyStateTitle}>No student metrics yet</Typography>
+          <Typography className={styles.emptyStateBody}>
+            Select a problem with a computed snapshot to inspect student-level matrices.
+          </Typography>
+        </Box>
+      ) : (
+        <Box className={styles.tableWrap}>
+          <table className={styles.metricsTable}>
+            <thead>
+              <tr>
+                <th>Student</th>
+                <th>Group</th>
+                <th>First Submission</th>
+                <th>First Correct</th>
+                <th>Post-Hint Solve Prob.</th>
+                <th>Attempts Before Hint</th>
+                <th>Attempts After Hint</th>
+                <th>Time to Solve After Hint</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.studentId}>
+                  <td>{row.studentName}</td>
+                  <td>{row.groupLabel}</td>
+                  <td>{row.timeToFirstSubmission}</td>
+                  <td>{row.timeToFirstCorrect}</td>
+                  <td>{row.postHintSolveProbability}</td>
+                  <td>{row.attemptsBeforeHint}</td>
+                  <td>{row.attemptsAfterHint}</td>
+                  <td>{row.timeToSolveAfterHint}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/fe/instructor/components/InstructorAnalysisSnapshotCard.tsx
+++ b/src/fe/instructor/components/InstructorAnalysisSnapshotCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import AutorenewRoundedIcon from "@mui/icons-material/AutorenewRounded";
+import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlineRounded";
+import PendingActionsRoundedIcon from "@mui/icons-material/PendingActionsRounded";
+import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
+import { Box, Typography } from "@mui/material";
+import type { InstructorAnalysisData } from "@/lib/types/instructorAnalysis";
+import styles from "@/fe/instructor/styles/ResearchAnalyticsPage.module.css";
+
+interface InstructorAnalysisSnapshotCardProps {
+  contestTitle: string;
+  contestDateLabel: string;
+  contestStatusLabel: string;
+  snapshot: InstructorAnalysisData["snapshot"];
+}
+
+function SnapshotIcon({ status }: { status: InstructorAnalysisData["snapshot"]["status"] }) {
+  if (status === "DONE") {
+    return <CheckCircleOutlineRoundedIcon className={styles.snapshotToneSuccess} />;
+  }
+
+  if (status === "FAILED") {
+    return <WarningAmberRoundedIcon className={styles.snapshotToneDanger} />;
+  }
+
+  if (status === "RUNNING") {
+    return <AutorenewRoundedIcon className={styles.snapshotToneInfo} />;
+  }
+
+  if (status === "QUEUED") {
+    return <PendingActionsRoundedIcon className={styles.snapshotToneMuted} />;
+  }
+
+  return <AccessTimeRoundedIcon className={styles.snapshotToneMuted} />;
+}
+
+export default function InstructorAnalysisSnapshotCard({
+  contestTitle,
+  contestDateLabel,
+  contestStatusLabel,
+  snapshot,
+}: InstructorAnalysisSnapshotCardProps) {
+  return (
+    <Box className={styles.card}>
+      <Box className={styles.cardHeader}>
+        <Box>
+          <Typography className={styles.cardEyebrow}>Snapshot Status</Typography>
+          <Typography className={styles.cardTitle}>{contestTitle}</Typography>
+          <Typography className={styles.cardDescription}>{contestDateLabel}</Typography>
+        </Box>
+        <Box className={styles.snapshotStatusBadge}>
+          <SnapshotIcon status={snapshot.status} />
+          <Typography className={styles.snapshotStatusText}>{snapshot.statusLabel}</Typography>
+        </Box>
+      </Box>
+
+      <Box className={styles.snapshotMetaGrid}>
+        <Box className={styles.snapshotMetaItem}>
+          <Typography className={styles.snapshotMetaLabel}>Requested View</Typography>
+          <Typography className={styles.snapshotMetaValue}>
+            {snapshot.requestedPreferenceLabel}
+          </Typography>
+        </Box>
+        <Box className={styles.snapshotMetaItem}>
+          <Typography className={styles.snapshotMetaLabel}>Resolved Snapshot</Typography>
+          <Typography className={styles.snapshotMetaValue}>{snapshot.resolvedTypeLabel}</Typography>
+        </Box>
+        <Box className={styles.snapshotMetaItem}>
+          <Typography className={styles.snapshotMetaLabel}>Contest Status</Typography>
+          <Typography className={styles.snapshotMetaValue}>{contestStatusLabel}</Typography>
+        </Box>
+        <Box className={styles.snapshotMetaItem}>
+          <Typography className={styles.snapshotMetaLabel}>Snapshot Watermark</Typography>
+          <Typography className={styles.snapshotMetaValue}>{snapshot.watermarkLabel}</Typography>
+        </Box>
+        <Box className={styles.snapshotMetaItem}>
+          <Typography className={styles.snapshotMetaLabel}>Last Compute</Typography>
+          <Typography className={styles.snapshotMetaValue}>{snapshot.computedAtLabel}</Typography>
+        </Box>
+      </Box>
+
+      <Box className={styles.snapshotMessageBox}>
+        <Typography className={styles.snapshotMessage}>{snapshot.message}</Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/src/fe/instructor/page/ResearchAnalyticsPage.tsx
+++ b/src/fe/instructor/page/ResearchAnalyticsPage.tsx
@@ -1,58 +1,95 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
-import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
-import {
-  Box,
-  Button,
-} from "@mui/material";
-import { mockResearchAnalyticsDataset } from "@/fe/instructor/data";
-import ComparisonAnalyticsSection from "@/fe/instructor/components/ComparisonAnalyticsSection";
-import HintEngagementTimelineCard from "@/fe/instructor/components/HintEngagementTimelineCard";
-import InstructorSubpageHeader from "@/fe/instructor/components/InstructorSubpageHeader";
-import ExportAnalysisDialog from "@/fe/instructor/components/ExportAnalysisDialog";
-import LiveInstructorAnalyticsCard from "@/fe/instructor/components/LiveInstructorAnalyticsCard";
-import SectionFiltersBar from "@/fe/instructor/components/SectionFiltersBar";
-import SolveTimeDistributionCard from "@/fe/instructor/components/SolveTimeDistributionCard";
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import EmojiEventsOutlinedIcon from "@mui/icons-material/EmojiEventsOutlined";
+import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
+import TableViewRoundedIcon from "@mui/icons-material/TableViewRounded";
+import { Box, Button } from "@mui/material";
+import InstructorAnalysisContestMetricsCard from "@/fe/instructor/components/InstructorAnalysisContestMetricsCard";
+import InstructorAnalysisExportActions from "@/fe/instructor/components/InstructorAnalysisExportActions";
+import InstructorAnalysisProblemMetricsCard from "@/fe/instructor/components/InstructorAnalysisProblemMetricsCard";
+import InstructorAnalysisSnapshotCard from "@/fe/instructor/components/InstructorAnalysisSnapshotCard";
+import SectionFiltersBar, {
+  type SectionFilterField,
+} from "@/fe/instructor/components/SectionFiltersBar";
 import PageHeader from "@/fe/shared/components/PageHeader";
+import SubpageHeader from "@/fe/shared/components/SubpageHeader";
 import { ROUTES } from "@/fe/shared/constants/routes";
 import ScrollbarHider from "@/fe/shared/components/ui/ScrollbarHider";
-import { useResearchAnalyticsComparisons } from "@/fe/instructor/page/useResearchAnalyticsComparisons";
-import { useResearchAnalyticsExport } from "@/fe/instructor/page/useResearchAnalyticsExport";
+import {
+  EMPTY_INSTRUCTOR_ANALYSIS_DATA,
+  EMPTY_PROBLEM_OPTION_VALUE,
+} from "@/fe/instructor/services/instructorAnalysis.constants";
+import { useInstructorAnalysis } from "@/fe/instructor/services/instructorAnalysis";
+import type { SnapshotPreference } from "@/lib/trpc/types/instructorAnalysis";
 import subpageStyles from "@/fe/instructor/styles/InstructorSubpageHeader.module.css";
 import styles from "@/fe/instructor/styles/ResearchAnalyticsPage.module.css";
 
 export default function ResearchAnalyticsPage() {
   const router = useRouter();
-  const { copy, dateRangeOptions, conditionOptions, gamificationTrendsByRange, aiHintTrendsByRange } =
-    mockResearchAnalyticsDataset;
-  const comparisons = useResearchAnalyticsComparisons({
-    conditionOptions,
-    gamificationTrendsByRange,
-    aiHintTrendsByRange,
-    sectionFilterIconClassName: styles.sectionFilterIcon,
+  const [contestId, setContestId] = useState<string | undefined>(undefined);
+  const [problemId, setProblemId] = useState<string | undefined>(undefined);
+  const [snapshotPreference, setSnapshotPreference] =
+    useState<SnapshotPreference>("latest");
+
+  const { data, isLoading, isFetching, isError, refetch } = useInstructorAnalysis({
+    contestId,
+    problemId,
+    snapshotPreference,
   });
-  const exportControls = useResearchAnalyticsExport({
-    activeAiHintTrend: comparisons.activeAiHintTrend,
-    activeGamificationTrend: comparisons.activeGamificationTrend,
-    contestComparisonRows: comparisons.contestComparisonRows,
-    groupComparisonRows: comparisons.groupComparisonRows,
-    leftContestLabel: comparisons.leftContestLabel,
-    leftGroupComparisonContestLabel: comparisons.leftGroupComparisonContestLabel,
-    leftGroupLabel: comparisons.leftGroupLabel,
-    leftStudentContestLabel: comparisons.leftStudentContestLabel,
-    leftStudentGroup: comparisons.studentComparisonFilters.leftGroup,
-    leftStudentLabel: comparisons.leftStudentLabel,
-    liveAnalyticsData: comparisons.liveAnalyticsData,
-    rightContestLabel: comparisons.rightContestLabel,
-    rightGroupComparisonContestLabel: comparisons.rightGroupComparisonContestLabel,
-    rightGroupLabel: comparisons.rightGroupLabel,
-    rightStudentContestLabel: comparisons.rightStudentContestLabel,
-    rightStudentGroup: comparisons.studentComparisonFilters.rightGroup,
-    rightStudentLabel: comparisons.rightStudentLabel,
-    studentComparisonRows: comparisons.studentComparisonRows,
-  });
+  const resolved = data ?? EMPTY_INSTRUCTOR_ANALYSIS_DATA;
+  const selectedContestValue = contestId ?? resolved.selection.contestId ?? "";
+  const selectedProblemValue =
+    problemId ??
+    resolved.selection.problemId ??
+    (resolved.filters.problems.length > 0
+      ? resolved.filters.problems[0].value
+      : EMPTY_PROBLEM_OPTION_VALUE);
+
+  const problemOptions = useMemo(() => {
+    if (resolved.filters.problems.length > 0) {
+      return resolved.filters.problems;
+    }
+
+    return [{ value: EMPTY_PROBLEM_OPTION_VALUE, label: "No problems available" }];
+  }, [resolved.filters.problems]);
+
+  const filterFields: SectionFilterField[] = [
+    {
+      id: "analysis-contest",
+      label: "Contest",
+      value: selectedContestValue,
+      options:
+        resolved.filters.contests.length > 0
+          ? resolved.filters.contests
+          : [{ value: "", label: "No contests available" }],
+      onChange: (value) => {
+        setContestId(value || undefined);
+        setProblemId(undefined);
+      },
+      icon: <EmojiEventsOutlinedIcon className={styles.sectionFilterIcon} />,
+    },
+    {
+      id: "analysis-problem",
+      label: "Problem",
+      value: selectedProblemValue,
+      options: problemOptions,
+      onChange: (value) => {
+        setProblemId(value === EMPTY_PROBLEM_OPTION_VALUE ? undefined : value);
+      },
+      icon: <TableViewRoundedIcon className={styles.sectionFilterIcon} />,
+    },
+    {
+      id: "analysis-snapshot",
+      label: "Snapshot",
+      value: snapshotPreference,
+      options: resolved.filters.snapshotPreferences,
+      onChange: (value) => setSnapshotPreference(value as SnapshotPreference),
+      icon: <AccessTimeRoundedIcon className={styles.sectionFilterIcon} />,
+    },
+  ];
 
   return (
     <>
@@ -61,127 +98,65 @@ export default function ResearchAnalyticsPage() {
         <Box className={styles.content}>
           <PageHeader
             onBack={() => router.push(ROUTES.instructor)}
-            backLabel={copy.backButtonLabel}
+            backLabel="Back to Instructor"
             backButtonClassName={subpageStyles.backButton}
           />
 
           <Box className={styles.heroBlock}>
-            <InstructorSubpageHeader
-              title={copy.pageTitle}
-              subtitle=""
+            <SubpageHeader
+              title="Matrices Dashboard"
+              subtitle="Post-contest instructor analytics built around preliminary (+5m) and final (+15m) snapshot windows."
               actions={
-                <Button
-                  className={styles.exportButton}
-                  startIcon={<FileDownloadOutlinedIcon />}
-                  variant="outlined"
-                  onClick={exportControls.onOpen}
-                >
-                  {copy.exportDataLabel}
-                </Button>
+                <Box className={styles.toolbarActions}>
+                  <InstructorAnalysisExportActions
+                    data={resolved}
+                    disabled={isLoading || isFetching || resolved.contest.title === null}
+                  />
+                  <Button
+                    className={styles.refreshButton}
+                    variant="outlined"
+                    startIcon={<RefreshRoundedIcon />}
+                    onClick={() => void refetch()}
+                    disabled={isFetching}
+                  >
+                    {isFetching ? "Refreshing..." : "Refresh Snapshot"}
+                  </Button>
+                </Box>
               }
             />
           </Box>
 
+          {isError ? (
+            <Box className={styles.errorBanner}>
+              Unable to load instructor analysis right now. Please retry once the metrics pipeline is available.
+            </Box>
+          ) : null}
+
           <Box className={styles.sectionBlock}>
-            <LiveInstructorAnalyticsCard
-              viewMode={comparisons.liveViewMode}
-              selectedContestId={comparisons.liveSelectedContestId}
-              onViewModeChange={comparisons.setLiveViewMode}
-              onSelectedContestIdChange={comparisons.setLiveSelectedContestId}
-            />
+            <SectionFiltersBar fields={filterFields} />
           </Box>
 
           <Box className={styles.sectionBlock}>
-            <ComparisonAnalyticsSection
-              title="Contest Comparison"
-              leftLabel={comparisons.leftContestLabel}
-              rightLabel={comparisons.rightContestLabel}
-              rows={comparisons.contestComparisonRows}
-              fields={comparisons.contestComparisonFields}
-            />
-          </Box>
-
-          <Box className={styles.sectionBlock}>
-            <ComparisonAnalyticsSection
-              title="Group Comparison"
-              leftLabel={comparisons.leftGroupLabel}
-              rightLabel={comparisons.rightGroupLabel}
-              rows={comparisons.groupComparisonRows}
-              fields={comparisons.groupComparisonFields}
-            />
-          </Box>
-
-          <Box className={styles.sectionBlock}>
-            <ComparisonAnalyticsSection
-              title="Student Comparison"
-              leftLabel={comparisons.leftStudentLabel}
-              rightLabel={comparisons.rightStudentLabel}
-              rows={comparisons.studentComparisonRows}
-              fields={comparisons.studentComparisonFields}
-            />
-          </Box>
-
-          <Box className={styles.sectionBlock}>
-            <SolveTimeDistributionCard
-              title="Gamification Statistics"
-              description=""
-              xLabels={comparisons.activeGamificationTrend.xLabels}
-              series={comparisons.activeGamificationTrend.series}
-              filters={
-                <SectionFiltersBar
-                  fields={[
-                    {
-                      id: "gamification-range",
-                      label: "Time Range",
-                      value: comparisons.gamificationDateRange,
-                      options: dateRangeOptions,
-                      onChange: comparisons.setGamificationDateRange,
-                      icon: <CalendarMonthOutlinedIcon className={styles.sectionFilterIcon} />,
-                    },
-                  ]}
-                />
+            <InstructorAnalysisSnapshotCard
+              contestTitle={
+                resolved.contest.title ??
+                (isLoading ? "Loading contest..." : "No instructor contests available")
               }
+              contestDateLabel={resolved.contest.dateLabel}
+              contestStatusLabel={resolved.contest.statusLabel}
+              snapshot={resolved.snapshot}
             />
           </Box>
 
           <Box className={styles.sectionBlock}>
-            <HintEngagementTimelineCard
-              title="AI Hint Statistics"
-              description=""
-              yAxisLabel="Overall cohort metric"
-              xLabels={comparisons.activeAiHintTrend.xLabels}
-              series={comparisons.activeAiHintTrend.series}
-              filters={
-                <SectionFiltersBar
-                  fields={[
-                    {
-                      id: "hint-range",
-                      label: "Time Range",
-                      value: comparisons.hintDateRange,
-                      options: dateRangeOptions,
-                      onChange: comparisons.setHintDateRange,
-                      icon: <CalendarMonthOutlinedIcon className={styles.sectionFilterIcon} />,
-                    },
-                  ]}
-                />
-              }
-            />
+            <InstructorAnalysisContestMetricsCard rows={resolved.contestGroupMetrics} />
+          </Box>
+
+          <Box className={styles.sectionBlock}>
+            <InstructorAnalysisProblemMetricsCard rows={resolved.problemStudentMetrics} />
           </Box>
         </Box>
       </Box>
-
-      <ExportAnalysisDialog
-        open={exportControls.isExportDialogOpen}
-        exportFormat={exportControls.exportFormat}
-        selectedSections={exportControls.selectedSections}
-        allSectionsSelected={exportControls.allSectionsSelected}
-        someSectionsSelected={exportControls.someSectionsSelected}
-        onClose={exportControls.onClose}
-        onExport={exportControls.onExport}
-        onExportFormatChange={exportControls.onExportFormatChange}
-        onToggleAll={exportControls.onToggleAll}
-        onToggleSection={exportControls.onToggleSection}
-      />
     </>
   );
 }

--- a/src/fe/instructor/services/instructorAnalysis.constants.ts
+++ b/src/fe/instructor/services/instructorAnalysis.constants.ts
@@ -1,0 +1,40 @@
+import type { InstructorAnalysisData } from "@/lib/types/instructorAnalysis";
+
+export const INSTRUCTOR_ANALYSIS_STALE_TIME_MS = 30_000;
+export const EMPTY_PROBLEM_OPTION_VALUE = "__no_problem__";
+
+export const EMPTY_INSTRUCTOR_ANALYSIS_DATA: InstructorAnalysisData = {
+  filters: {
+    contests: [],
+    problems: [],
+    snapshotPreferences: [
+      { value: "latest", label: "Latest Available" },
+      { value: "preliminary", label: "Preliminary (+5m)" },
+      { value: "final", label: "Final (+15m)" },
+    ],
+  },
+  selection: {
+    contestId: null,
+    problemId: null,
+    snapshotPreference: "latest",
+  },
+  contest: {
+    id: null,
+    title: null,
+    dateLabel: "No contest selected",
+    statusLabel: "No snapshot available yet",
+  },
+  snapshot: {
+    requestedPreference: "latest",
+    requestedPreferenceLabel: "Latest available",
+    resolvedType: null,
+    resolvedTypeLabel: "No snapshot available yet",
+    status: "NOT_READY",
+    statusLabel: "Waiting",
+    watermarkLabel: "Watermark not scheduled",
+    computedAtLabel: "Not computed yet",
+    message: "Choose an instructor contest to inspect post-contest matrices.",
+  },
+  contestGroupMetrics: [],
+  problemStudentMetrics: [],
+};

--- a/src/fe/instructor/services/instructorAnalysis.export.ts
+++ b/src/fe/instructor/services/instructorAnalysis.export.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import type { InstructorAnalysisData } from "@/lib/types/instructorAnalysis";
+
+function sanitizeFilePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function buildFileStem(data: InstructorAnalysisData): string {
+  const contestPart = sanitizeFilePart(data.contest.title ?? "analysis");
+  const snapshotPart = sanitizeFilePart(data.snapshot.resolvedTypeLabel);
+  return `instructor-analysis-${contestPart}-${snapshotPart}`;
+}
+
+function downloadBlob(filename: string, mimeType: string, content: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+function escapeCsvCell(value: string): string {
+  const escaped = value.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+function buildCsvRow(values: string[]): string {
+  return values.map(escapeCsvCell).join(",");
+}
+
+export function exportInstructorAnalysisJson(data: InstructorAnalysisData): void {
+  const payload = {
+    selection: data.selection,
+    contest: data.contest,
+    snapshot: data.snapshot,
+    contestGroupMetrics: data.contestGroupMetrics,
+    problemStudentMetrics: data.problemStudentMetrics,
+  };
+
+  downloadBlob(
+    `${buildFileStem(data)}.json`,
+    "application/json;charset=utf-8",
+    `${JSON.stringify(payload, null, 2)}\n`,
+  );
+}
+
+export function exportInstructorAnalysisCsv(data: InstructorAnalysisData): void {
+  const lines: string[] = [
+    buildCsvRow(["Section", "Field", "Value"]),
+    buildCsvRow(["snapshot", "contest", data.contest.title ?? "-"]),
+    buildCsvRow(["snapshot", "contestStatus", data.contest.statusLabel]),
+    buildCsvRow(["snapshot", "requestedPreference", data.snapshot.requestedPreferenceLabel]),
+    buildCsvRow(["snapshot", "resolvedSnapshot", data.snapshot.resolvedTypeLabel]),
+    buildCsvRow(["snapshot", "status", data.snapshot.statusLabel]),
+    buildCsvRow(["snapshot", "watermark", data.snapshot.watermarkLabel]),
+    buildCsvRow(["snapshot", "computedAt", data.snapshot.computedAtLabel]),
+    buildCsvRow(["snapshot", "message", data.snapshot.message]),
+    "",
+    buildCsvRow([
+      "contestGroupMetrics",
+      "group",
+      "solveRate",
+      "meanSolveTime",
+      "medianSolveTime",
+      "attemptsToSolve",
+    ]),
+    ...data.contestGroupMetrics.map((row) =>
+      buildCsvRow([
+        "",
+        row.groupLabel,
+        row.solveRate,
+        row.meanSolveTime,
+        row.medianSolveTime,
+        row.attemptsToSolve,
+      ]),
+    ),
+    "",
+    buildCsvRow([
+      "problemStudentMetrics",
+      "studentId",
+      "studentName",
+      "group",
+      "timeToFirstSubmission",
+      "timeToFirstCorrect",
+      "postHintSolveProbability",
+      "attemptsBeforeHint",
+      "attemptsAfterHint",
+      "timeToSolveAfterHint",
+    ]),
+    ...data.problemStudentMetrics.map((row) =>
+      buildCsvRow([
+        "",
+        row.studentId,
+        row.studentName,
+        row.groupLabel,
+        row.timeToFirstSubmission,
+        row.timeToFirstCorrect,
+        row.postHintSolveProbability,
+        row.attemptsBeforeHint,
+        row.attemptsAfterHint,
+        row.timeToSolveAfterHint,
+      ]),
+    ),
+  ];
+
+  downloadBlob(`${buildFileStem(data)}.csv`, "text/csv;charset=utf-8", lines.join("\n"));
+}

--- a/src/fe/instructor/services/instructorAnalysis.mapper.ts
+++ b/src/fe/instructor/services/instructorAnalysis.mapper.ts
@@ -1,0 +1,201 @@
+import type {
+  InstructorAnalysisContestGroupMetricRow,
+  InstructorAnalysisData,
+  InstructorAnalysisProblemStudentMetricRow,
+} from "@/lib/types/instructorAnalysis";
+import type {
+  InstructorAnalysisResponse,
+  SnapshotPreference,
+  SnapshotRunStatus,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+
+function formatPercent(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return `${value.toFixed(1)}%`;
+}
+
+function formatNumber(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  if (Number.isInteger(value)) {
+    return String(value);
+  }
+
+  return value.toFixed(1);
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) {
+    return "-";
+  }
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    return `${minutes.toFixed(1)} min`;
+  }
+
+  const hours = minutes / 60;
+  return `${hours.toFixed(1)} hr`;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(timestamp);
+}
+
+function buildContestDateLabel(startsAt: string | null, endsAt: string | null): string {
+  if (!startsAt) {
+    return "Schedule unavailable";
+  }
+
+  const startLabel = formatDateTime(startsAt);
+  if (!endsAt) {
+    return `Starts ${startLabel}`;
+  }
+
+  return `Starts ${startLabel} · Ends ${formatDateTime(endsAt)}`;
+}
+
+function buildSnapshotStatusLabel(
+  status: SnapshotRunStatus,
+  resolvedType: SnapshotType | null,
+): string {
+  if (status === "NOT_READY") {
+    return "Waiting for snapshot window";
+  }
+
+  if (status === "FAILED") {
+    return "Snapshot failed";
+  }
+
+  if (status === "RUNNING") {
+    return "Snapshot computing";
+  }
+
+  if (status === "QUEUED") {
+    return "Snapshot queued";
+  }
+
+  if (resolvedType === "FINAL_15M") {
+    return "Final snapshot";
+  }
+
+  if (resolvedType === "PRELIMINARY_5M") {
+    return "Preliminary snapshot";
+  }
+
+  return "Snapshot ready";
+}
+
+function buildSnapshotPreferenceLabel(value: SnapshotPreference): string {
+  if (value === "preliminary") {
+    return "Preliminary (+5m)";
+  }
+
+  if (value === "final") {
+    return "Final (+15m)";
+  }
+
+  return "Latest available";
+}
+
+function buildResolvedSnapshotLabel(value: SnapshotType | null): string {
+  if (value === "PRELIMINARY_5M") {
+    return "Preliminary (+5m)";
+  }
+
+  if (value === "FINAL_15M") {
+    return "Final (+15m)";
+  }
+
+  return "No snapshot available yet";
+}
+
+function mapContestGroupRow(
+  row: InstructorAnalysisResponse["contestGroupMetrics"]["rows"][number],
+): InstructorAnalysisContestGroupMetricRow {
+  return {
+    groupLabel: `Group ${row.groupName}`,
+    solveRate: formatPercent(row.solveRate),
+    meanSolveTime: formatDuration(row.meanSolveTimeSec),
+    medianSolveTime: formatDuration(row.medianSolveTimeSec),
+    attemptsToSolve: formatNumber(row.attemptsToSolveMean),
+  };
+}
+
+function mapProblemStudentRow(
+  row: InstructorAnalysisResponse["problemStudentMetrics"]["rows"][number],
+): InstructorAnalysisProblemStudentMetricRow {
+  return {
+    studentId: row.studentId,
+    studentName: row.studentName,
+    groupLabel: row.groupName ? `Group ${row.groupName}` : "-",
+    timeToFirstSubmission: formatDuration(row.timeToFirstSubmissionSec),
+    timeToFirstCorrect: formatDuration(row.timeToFirstCorrectSec),
+    postHintSolveProbability: formatPercent(row.postHintSolveProbability),
+    attemptsBeforeHint: formatNumber(row.attemptsBeforeHint),
+    attemptsAfterHint: formatNumber(row.attemptsAfterHint),
+    timeToSolveAfterHint: formatDuration(row.timeToSolveAfterHintSec),
+  };
+}
+
+export function mapInstructorAnalysisResponse(
+  payload: InstructorAnalysisResponse,
+): InstructorAnalysisData {
+  return {
+    filters: payload.filters,
+    selection: payload.selection,
+    contest: {
+      id: payload.contest.id,
+      title: payload.contest.title,
+      dateLabel: buildContestDateLabel(payload.contest.startsAt, payload.contest.endsAt),
+      statusLabel: payload.contest.status ?? "No contest selected",
+    },
+    snapshot: {
+      requestedPreference: payload.snapshot.requestedPreference,
+      requestedPreferenceLabel: buildSnapshotPreferenceLabel(
+        payload.snapshot.requestedPreference,
+      ),
+      resolvedType: payload.snapshot.resolvedType,
+      resolvedTypeLabel: buildResolvedSnapshotLabel(payload.snapshot.resolvedType),
+      status: payload.snapshot.status,
+      statusLabel: buildSnapshotStatusLabel(
+        payload.snapshot.status,
+        payload.snapshot.resolvedType,
+      ),
+      watermarkLabel: payload.snapshot.watermark
+        ? `Watermark ${formatDateTime(payload.snapshot.watermark)}`
+        : "Watermark not available yet",
+      computedAtLabel: payload.snapshot.computedAt
+        ? `Computed ${formatDateTime(payload.snapshot.computedAt)}`
+        : "Not computed yet",
+      message: payload.snapshot.message,
+    },
+    contestGroupMetrics: payload.contestGroupMetrics.rows.map(mapContestGroupRow),
+    problemStudentMetrics: payload.problemStudentMetrics.rows.map(mapProblemStudentRow),
+  };
+}

--- a/src/fe/instructor/services/instructorAnalysis.ts
+++ b/src/fe/instructor/services/instructorAnalysis.ts
@@ -1,0 +1,38 @@
+import type { InstructorAnalysisData } from "@/lib/types/instructorAnalysis";
+import type { SnapshotPreference } from "@/lib/trpc/types/instructorAnalysis";
+import { trpc } from "@/lib/trpc/client";
+import {
+  EMPTY_INSTRUCTOR_ANALYSIS_DATA,
+  INSTRUCTOR_ANALYSIS_STALE_TIME_MS,
+} from "./instructorAnalysis.constants";
+import { mapInstructorAnalysisResponse } from "./instructorAnalysis.mapper";
+
+export { EMPTY_INSTRUCTOR_ANALYSIS_DATA };
+
+interface UseInstructorAnalysisInput {
+  contestId?: string;
+  problemId?: string;
+  snapshotPreference: SnapshotPreference;
+}
+
+export function useInstructorAnalysis(
+  input: UseInstructorAnalysisInput,
+): {
+  data: InstructorAnalysisData | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => Promise<unknown>;
+} {
+  const query = trpc.instructorAnalysis.get.useQuery(input, {
+    staleTime: INSTRUCTOR_ANALYSIS_STALE_TIME_MS,
+  });
+
+  return {
+    data: query.data ? mapInstructorAnalysisResponse(query.data) : undefined,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}

--- a/src/fe/instructor/styles/ResearchAnalyticsPage.module.css
+++ b/src/fe/instructor/styles/ResearchAnalyticsPage.module.css
@@ -4,7 +4,6 @@
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  font-family: Inter, sans-serif;
 }
 
 .content {
@@ -12,7 +11,7 @@
   flex-direction: column;
   gap: 24px;
   margin: 0 auto;
-  max-width: 1400px;
+  max-width: 1360px;
   padding: 24px 32px 32px;
   width: 100%;
 }
@@ -20,24 +19,44 @@
 .heroBlock {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.toolbarActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.refreshButton {
+  text-transform: none !important;
+  border-radius: 8px !important;
+  box-shadow: none !important;
+}
+
+.exportActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .exportButton {
   text-transform: none !important;
-  border-radius: 6px !important;
-  border-color: rgba(0, 0, 0, 0.1) !important;
-  color: #0a0a0a !important;
-  background: #ffffff !important;
-  height: 36px;
-  padding: 8px 14px !important;
-  font-size: 12px !important;
-  line-height: 18px !important;
-  font-weight: 500 !important;
+  border-radius: 8px !important;
+  box-shadow: none !important;
 }
 
-.exportButton:hover {
-  background: #f9fafb !important;
+.errorBanner {
+  border: 1px solid rgba(180, 35, 24, 0.18);
+  border-radius: 12px;
+  background: #fff5f4;
+  color: #b42318;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
 }
 
 .sectionBlock {
@@ -47,106 +66,44 @@
 }
 
 .card {
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 12px !important;
-  box-shadow: none !important;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
   background: #ffffff;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.04);
+  padding: 22px 24px;
 }
 
-.cardContent {
+.cardHeader {
   display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 24px !important;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 18px;
 }
 
-.cardTopBlock {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.cardTitleRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.cardIcon {
-  width: 20px !important;
-  height: 20px !important;
-  color: #4a5565;
+.cardEyebrow {
+  color: #9a3412;
+  font-size: 12px !important;
+  line-height: 16px !important;
+  font-weight: 700 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px !important;
 }
 
 .cardTitle {
-  margin: 0;
-  font-size: 18px !important;
-  line-height: 22px !important;
-  font-weight: 600 !important;
-  color: #0a0a0a;
-}
-
-.cardTitleLarge {
-  margin: 0;
-  font-size: 28px !important;
+  color: #111827;
+  font-size: 22px !important;
   line-height: 28px !important;
-  font-weight: 400 !important;
-  color: #0a0a0a;
+  font-weight: 700 !important;
 }
 
 .cardDescription {
-  margin: 0;
-  color: #717182;
+  color: #4b5563;
   font-size: 14px !important;
   line-height: 20px !important;
-}
-
-.cardFiltersWrap {
-  padding-top: 2px;
-}
-
-.filterCard {
-  border-width: 2px;
-}
-
-.filtersGrid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.filterField {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.filterLabelRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.filterLabelIcon {
-  width: 16px !important;
-  height: 16px !important;
-  color: #6a7282;
-}
-
-.filterLabel {
-  font-size: 14px !important;
-  line-height: 20px !important;
-  font-weight: 500 !important;
-  color: #0a0a0a;
-}
-
-.selectInput {
-  background: #f3f3f5;
-  border-radius: 6px;
-}
-
-.selectInput :global(.MuiOutlinedInput-notchedOutline) {
-  border-color: transparent !important;
+  margin-top: 6px !important;
+  max-width: 720px;
 }
 
 .sectionFiltersBar {
@@ -196,327 +153,167 @@
   border-color: rgba(0, 0, 0, 0.08) !important;
 }
 
-.exportDialogContent {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding-top: 8px !important;
-}
-
-.exportDialogCopy {
-  font-size: 14px !important;
-  line-height: 20px !important;
-  color: #4a5565;
-}
-
-.exportSectionList {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 12px;
-  background: #ffffff;
-  padding: 14px;
-}
-
-.exportCheckbox {
-  margin: 0 !important;
-  align-items: center !important;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 10px;
-  background: #f9fafb;
-  padding: 6px 8px;
-}
-
-.exportCheckbox :global(.MuiCheckbox-root) {
-  color: #b42318;
-}
-
-.exportCheckbox :global(.MuiCheckbox-root.Mui-checked) {
-  color: #b42318;
-}
-
-.exportCheckbox :global(.MuiFormControlLabel-label) {
-  font-size: 13px;
-  line-height: 18px;
-  color: #101828;
-}
-
-.exportFormatRow {
-  display: flex;
+.snapshotStatusBadge {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding-top: 10px;
+  gap: 8px;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #9a3412;
+  padding: 8px 12px;
 }
 
-.exportFormatLabel {
+.snapshotStatusText {
   font-size: 13px !important;
   line-height: 18px !important;
   font-weight: 600 !important;
-  color: #0a0a0a;
 }
 
-.exportFormatControl {
-  min-width: 160px;
+.snapshotToneSuccess,
+.snapshotToneDanger,
+.snapshotToneInfo,
+.snapshotToneMuted {
+  width: 18px !important;
+  height: 18px !important;
 }
 
-.exportFormatControl :global(.MuiOutlinedInput-root) {
-  background: #ffffff;
-  border-radius: 8px;
+.snapshotToneSuccess {
+  color: #15803d;
 }
 
-.exportFormatControl :global(.MuiOutlinedInput-notchedOutline) {
-  border-color: rgba(0, 0, 0, 0.12) !important;
+.snapshotToneDanger {
+  color: #b42318;
 }
 
-.kpiGrid {
+.snapshotToneInfo {
+  color: #1d4ed8;
+}
+
+.snapshotToneMuted {
+  color: #6b7280;
+}
+
+.snapshotMetaGrid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 24px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 14px;
 }
 
-.kpiRiskCard {
-  background: #fff7ed;
-  border-color: #ffd6a7;
+.snapshotMetaItem {
+  border-radius: 12px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 14px;
 }
 
-.kpiCardContent {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-height: 132px;
-  justify-content: flex-start;
-}
-
-.kpiLabel {
-  color: #4a5565;
-  font-size: 14px !important;
-  line-height: 20px !important;
-}
-
-.kpiLabelRisk {
-  color: #ca3500;
-  font-size: 14px !important;
-  line-height: 20px !important;
-}
-
-.kpiValue {
-  margin-top: 18px !important;
-  font-size: 42px !important;
-  line-height: 44px !important;
-  font-weight: 700 !important;
-  color: #0a0a0a;
-}
-
-.kpiValueRisk {
-  margin-top: 18px !important;
-  font-size: 42px !important;
-  line-height: 44px !important;
-  font-weight: 700 !important;
-  color: #7e2a0c;
-}
-
-.kpiCaptionGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.kpiCaption {
-  color: #4a5565;
+.snapshotMetaLabel {
+  color: #6b7280;
   font-size: 12px !important;
   line-height: 16px !important;
-}
-
-.kpiCaptionMultiline {
-  white-space: pre-line;
-}
-
-.kpiRiskCaptionRow {
-  display: flex;
-  align-items: flex-start;
-  gap: 4px;
-}
-
-.kpiRiskIcon {
-  width: 12px !important;
-  height: 12px !important;
-  margin-top: 2px;
-  color: #ca3500;
-}
-
-.kpiCaptionDanger {
-  color: #ca3500;
-  font-size: 12px !important;
-  line-height: 16px !important;
-}
-
-.twoColGrid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 24px;
-  align-items: start;
-}
-
-.chartHeaderRow {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding-top: 2px;
-}
-
-.muiChartBox {
-  position: relative;
-  margin-top: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 10px;
-  padding: 8px 10px 6px;
-}
-
-.chartAxisOverlay {
-  position: absolute;
-  height: 56px;
-  pointer-events: none;
-}
-
-.chartAxisLine {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: 1px;
-  background: rgba(0, 0, 0, 0.18);
-}
-
-.axisContestItem {
-  position: absolute;
-  transform: translateX(-50%);
-  top: 0;
-}
-
-.axisContestLabel {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 10px !important;
-  line-height: 12px !important;
-  font-weight: 500 !important;
-  color: #4a5565;
-  white-space: nowrap;
-  background: rgba(255, 255, 255, 0.9);
-  padding: 1px 4px;
-  border-radius: 4px;
-}
-
-.axisContestDot {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  top: -3px;
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: #4a5565;
-  border: 2px solid #ffffff;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-}
-
-.axisSemesterItem {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  top: 0;
-}
-
-.axisSemesterTick {
-  width: 1px;
-  height: 10px;
-  background: rgba(0, 0, 0, 0.22);
-  margin-top: -1px;
-  margin-bottom: 4px;
-}
-
-.axisSemesterLabel {
-  font-size: 13px !important;
-  line-height: 15px !important;
   font-weight: 600 !important;
-  color: #344054;
+  margin-bottom: 6px !important;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.snapshotMetaValue {
+  color: #111827;
+  font-size: 14px !important;
+  line-height: 20px !important;
+  font-weight: 600 !important;
+}
+
+.snapshotMessageBox {
+  margin-top: 16px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #fff7ed 0%, #fffbeb 100%);
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  padding: 14px 16px;
+}
+
+.snapshotMessage {
+  color: #9a3412;
+  font-size: 14px !important;
+  line-height: 20px !important;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.metricsTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 880px;
+}
+
+.metricsTable th {
+  color: #6b7280;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: left;
+  padding: 0 12px 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.24);
   white-space: nowrap;
 }
 
-@media (max-width: 1024px) {
-  .twoColGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .groupCompareHeader,
-  .groupCompareRow {
-    grid-template-columns: 1fr;
-  }
-
-  .groupCompareCenterLabel {
-    display: none;
-  }
-
-  .groupCompareMetricCenter {
-    order: -1;
-  }
-
-  .axisContestLabel {
-    font-size: 10px !important;
-  }
-
-  .axisSemesterLabel {
-    font-size: 12px !important;
-  }
+.metricsTable td {
+  color: #111827;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 12px 14px 0;
+  border-bottom: 1px solid rgba(241, 245, 249, 1);
+  vertical-align: top;
 }
 
-.chartBlock {
-  margin-top: 8px;
-}
-
-.groupHeader {
+.emptyState {
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  background: #f8fafc;
+  padding: 28px 24px;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
+  text-align: center;
 }
 
-.groupTitleEarly,
-.groupTitleDelayed {
-  font-size: 20px !important;
+.emptyStateIcon {
+  width: 28px !important;
+  height: 28px !important;
+  color: #9ca3af;
+  margin-bottom: 12px;
+}
+
+.emptyStateTitle {
+  color: #111827;
+  font-size: 16px !important;
+  line-height: 22px !important;
+  font-weight: 700 !important;
+  margin-bottom: 6px !important;
+}
+
+.emptyStateBody {
+  color: #6b7280;
+  font-size: 14px !important;
   line-height: 20px !important;
-  font-weight: 500 !important;
+  max-width: 560px;
 }
 
-.groupTitleEarly {
-  color: #007aff;
-}
+@media (max-width: 900px) {
+  .content {
+    padding: 20px 20px 28px;
+  }
 
-.groupTitleDelayed {
-  color: #34c759;
-}
+  .snapshotMetaGrid {
+    grid-template-columns: 1fr;
+  }
 
-.earlySampleChip,
-.delayedSampleChip {
-  height: 22px !important;
-  border-radius: 6px !important;
-  font-size: 12px !important;
-  font-weight: 500 !important;
-}
-
-.earlySampleChip {
-  background: rgba(0, 122, 255, 0.12) !important;
-  color: #007aff !important;
-}
-
-.delayedSampleChip {
-  background: rgba(52, 199, 89, 0.14) !important;
-  color: #34c759 !important;
+  .card {
+    padding: 18px 18px;
+  }
 }
 
 .progressRow {

--- a/src/lib/trpc/types/instructorAnalysis.ts
+++ b/src/lib/trpc/types/instructorAnalysis.ts
@@ -1,0 +1,66 @@
+export type SnapshotPreference = "latest" | "preliminary" | "final";
+export type SnapshotType = "PRELIMINARY_5M" | "FINAL_15M";
+export type SnapshotRunStatus = "QUEUED" | "RUNNING" | "DONE" | "FAILED" | "NOT_READY";
+
+export interface InstructorAnalysisFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface InstructorAnalysisContestGroupMetric {
+  groupName: "A" | "B" | "C";
+  solveRate: number;
+  meanSolveTimeSec: number | null;
+  medianSolveTimeSec: number | null;
+  attemptsToSolveMean: number | null;
+}
+
+export interface InstructorAnalysisProblemStudentMetric {
+  studentId: string;
+  studentName: string;
+  groupName: "A" | "B" | "C" | null;
+  timeToFirstSubmissionSec: number | null;
+  timeToFirstCorrectSec: number | null;
+  postHintSolveProbability: number | null;
+  attemptsBeforeHint: number | null;
+  attemptsAfterHint: number | null;
+  timeToSolveAfterHintSec: number | null;
+}
+
+export interface InstructorAnalysisResponse {
+  role: "instructor";
+  filters: {
+    contests: InstructorAnalysisFilterOption[];
+    problems: InstructorAnalysisFilterOption[];
+    snapshotPreferences: Array<{
+      value: SnapshotPreference;
+      label: string;
+    }>;
+  };
+  selection: {
+    contestId: string | null;
+    problemId: string | null;
+    snapshotPreference: SnapshotPreference;
+  };
+  contest: {
+    id: string | null;
+    title: string | null;
+    startsAt: string | null;
+    endsAt: string | null;
+    status: "Draft" | "Upcoming" | "Active" | "Ended" | null;
+  };
+  snapshot: {
+    requestedPreference: SnapshotPreference;
+    resolvedType: SnapshotType | null;
+    status: SnapshotRunStatus;
+    watermark: string | null;
+    computedAt: string | null;
+    message: string;
+  };
+  contestGroupMetrics: {
+    rows: InstructorAnalysisContestGroupMetric[];
+  };
+  problemStudentMetrics: {
+    rows: InstructorAnalysisProblemStudentMetric[];
+  };
+}

--- a/src/lib/types/instructorAnalysis.ts
+++ b/src/lib/types/instructorAnalysis.ts
@@ -1,0 +1,65 @@
+import type {
+  SnapshotPreference,
+  SnapshotRunStatus,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+
+export interface InstructorAnalysisFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface InstructorAnalysisContestGroupMetricRow {
+  groupLabel: string;
+  solveRate: string;
+  meanSolveTime: string;
+  medianSolveTime: string;
+  attemptsToSolve: string;
+}
+
+export interface InstructorAnalysisProblemStudentMetricRow {
+  studentId: string;
+  studentName: string;
+  groupLabel: string;
+  timeToFirstSubmission: string;
+  timeToFirstCorrect: string;
+  postHintSolveProbability: string;
+  attemptsBeforeHint: string;
+  attemptsAfterHint: string;
+  timeToSolveAfterHint: string;
+}
+
+export interface InstructorAnalysisData {
+  filters: {
+    contests: InstructorAnalysisFilterOption[];
+    problems: InstructorAnalysisFilterOption[];
+    snapshotPreferences: Array<{
+      value: SnapshotPreference;
+      label: string;
+    }>;
+  };
+  selection: {
+    contestId: string | null;
+    problemId: string | null;
+    snapshotPreference: SnapshotPreference;
+  };
+  contest: {
+    id: string | null;
+    title: string | null;
+    dateLabel: string;
+    statusLabel: string;
+  };
+  snapshot: {
+    requestedPreference: SnapshotPreference;
+    requestedPreferenceLabel: string;
+    resolvedType: SnapshotType | null;
+    resolvedTypeLabel: string;
+    status: SnapshotRunStatus;
+    statusLabel: string;
+    watermarkLabel: string;
+    computedAtLabel: string;
+    message: string;
+  };
+  contestGroupMetrics: InstructorAnalysisContestGroupMetricRow[];
+  problemStudentMetrics: InstructorAnalysisProblemStudentMetricRow[];
+}

--- a/src/server/instructorAnalysis/metrics.ts
+++ b/src/server/instructorAnalysis/metrics.ts
@@ -1,0 +1,249 @@
+import type { ExperimentGroup } from "@prisma/client";
+import type { SnapshotType } from "@/lib/trpc/types/instructorAnalysis";
+
+interface ContestMetricInput {
+  id: string;
+  startsAt: Date;
+  contestProblems: Array<{
+    problem: {
+      id: string;
+    };
+  }>;
+  experimentGroups: Array<{
+    groupName: ExperimentGroup;
+  }>;
+  participations: Array<{
+    userId: string;
+    role: string;
+    experimentGroup: ExperimentGroup | null;
+    user: {
+      firstName: string;
+      lastName: string;
+    };
+  }>;
+  contestProblemSessions: Array<{
+    userId: string;
+    problemId: string;
+    startedAt: Date;
+    firstSubmitAt: Date | null;
+    hintTriggeredAt: Date | null;
+    solvedAt: Date | null;
+    solved: boolean;
+  }>;
+  submissions: Array<{
+    userId: string;
+    problemId: string;
+    createdAt: Date;
+  }>;
+}
+
+export interface ComputedContestGroupMetricsRow {
+  contestId: string;
+  groupName: ExperimentGroup;
+  snapshotType: SnapshotType;
+  watermark: Date;
+  solveRate: number;
+  meanSolveTimeSec: number | null;
+  medianSolveTimeSec: number | null;
+  attemptsToSolveMean: number | null;
+}
+
+export interface ComputedProblemStudentMetricsRow {
+  contestId: string;
+  problemId: string;
+  studentId: string;
+  snapshotType: SnapshotType;
+  watermark: Date;
+  groupName: ExperimentGroup | null;
+  timeToFirstSubmissionSec: number | null;
+  timeToFirstCorrectSec: number | null;
+  postHintSolveProbability: number | null;
+  attemptsBeforeHint: number | null;
+  attemptsAfterHint: number | null;
+  timeToSolveAfterHintSec: number | null;
+}
+
+function toSeconds(start: Date, end: Date | null): number | null {
+  if (!end) {
+    return null;
+  }
+
+  const diff = Math.round((end.getTime() - start.getTime()) / 1000);
+  return diff >= 0 ? diff : null;
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+
+  return Math.round((sorted[middle - 1] + sorted[middle]) / 2);
+}
+
+function buildSubmissionMap(contest: ContestMetricInput, watermark: Date): Map<string, Date[]> {
+  const map = new Map<string, Date[]>();
+
+  contest.submissions.forEach((submission) => {
+    if (submission.createdAt.getTime() > watermark.getTime()) {
+      return;
+    }
+
+    const key = `${submission.userId}:${submission.problemId}`;
+    const current = map.get(key) ?? [];
+    current.push(submission.createdAt);
+    map.set(key, current);
+  });
+
+  map.forEach((entries, key) => {
+    map.set(
+      key,
+      entries.sort((left, right) => left.getTime() - right.getTime()),
+    );
+  });
+
+  return map;
+}
+
+export function computeInstructorMetricsSnapshot(
+  contest: ContestMetricInput,
+  snapshotType: SnapshotType,
+  watermark: Date,
+): {
+  contestGroupRows: ComputedContestGroupMetricsRow[];
+  problemStudentRows: ComputedProblemStudentMetricsRow[];
+} {
+  const contestantParticipations = contest.participations.filter(
+    (participation) => participation.role === "contestant",
+  );
+  const problemIds = contest.contestProblems.map((entry) => entry.problem.id);
+  const submissionMap = buildSubmissionMap(contest, watermark);
+  const sessionsByUserProblem = new Map(
+    contest.contestProblemSessions
+      .filter((session) => session.startedAt.getTime() <= watermark.getTime())
+      .map((session) => [`${session.userId}:${session.problemId}`, session] as const),
+  );
+  const groups = Array.from(
+    new Set<ExperimentGroup>([
+      ...contest.experimentGroups.map((group) => group.groupName),
+      ...contestantParticipations
+        .map((participation) => participation.experimentGroup)
+        .filter((group): group is ExperimentGroup => group !== null),
+    ]),
+  ).sort();
+
+  const contestGroupRows = groups.map((groupName) => {
+    const groupParticipants = contestantParticipations.filter(
+      (participation) => participation.experimentGroup === groupName,
+    );
+    const totalExpected = groupParticipants.length * problemIds.length;
+    let solvedCount = 0;
+    const solveDurations: number[] = [];
+    const attemptsToSolve: number[] = [];
+
+    groupParticipants.forEach((participation) => {
+      problemIds.forEach((problemId) => {
+        const session = sessionsByUserProblem.get(`${participation.userId}:${problemId}`);
+        const solvedAt =
+          session?.solved && session.solvedAt && session.solvedAt.getTime() <= watermark.getTime()
+            ? session.solvedAt
+            : null;
+
+        if (!session || !solvedAt) {
+          return;
+        }
+
+        solvedCount += 1;
+        const solveSeconds = toSeconds(session.startedAt, solvedAt);
+        if (solveSeconds !== null) {
+          solveDurations.push(solveSeconds);
+        }
+
+        const submissions = submissionMap.get(`${participation.userId}:${problemId}`) ?? [];
+        attemptsToSolve.push(
+          submissions.filter((submittedAt) => submittedAt.getTime() <= solvedAt.getTime()).length,
+        );
+      });
+    });
+
+    const meanSolveTimeSec = average(solveDurations);
+    const attemptsToSolveMean = average(attemptsToSolve);
+
+    return {
+      contestId: contest.id,
+      groupName,
+      snapshotType,
+      watermark,
+      solveRate: totalExpected === 0 ? 0 : Math.round((solvedCount / totalExpected) * 1000) / 10,
+      meanSolveTimeSec: meanSolveTimeSec === null ? null : Math.round(meanSolveTimeSec),
+      medianSolveTimeSec: median(solveDurations),
+      attemptsToSolveMean:
+        attemptsToSolveMean === null ? null : Math.round(attemptsToSolveMean * 10) / 10,
+    };
+  });
+
+  const problemStudentRows = contest.contestProblems.flatMap((entry) =>
+    contestantParticipations
+      .slice()
+      .sort((left, right) => {
+        const leftName = `${left.user.firstName} ${left.user.lastName}`;
+        const rightName = `${right.user.firstName} ${right.user.lastName}`;
+        return leftName.localeCompare(rightName);
+      })
+      .map((participation) => {
+        const session = sessionsByUserProblem.get(`${participation.userId}:${entry.problem.id}`);
+        const submissions = submissionMap.get(`${participation.userId}:${entry.problem.id}`) ?? [];
+        const solvedAt =
+          session?.solved && session.solvedAt && session.solvedAt.getTime() <= watermark.getTime()
+            ? session.solvedAt
+            : null;
+        const hintTriggeredAt =
+          session?.hintTriggeredAt && session.hintTriggeredAt.getTime() <= watermark.getTime()
+            ? session.hintTriggeredAt
+            : null;
+        const anchorStart = session?.startedAt ?? contest.startsAt;
+        const firstSubmissionAt =
+          session?.firstSubmitAt && session.firstSubmitAt.getTime() <= watermark.getTime()
+            ? session.firstSubmitAt
+            : submissions[0] ?? null;
+
+        return {
+          contestId: contest.id,
+          problemId: entry.problem.id,
+          studentId: participation.userId,
+          snapshotType,
+          watermark,
+          groupName: participation.experimentGroup,
+          timeToFirstSubmissionSec: toSeconds(anchorStart, firstSubmissionAt),
+          timeToFirstCorrectSec: toSeconds(anchorStart, solvedAt),
+          postHintSolveProbability: hintTriggeredAt ? (solvedAt ? 100 : 0) : null,
+          attemptsBeforeHint: hintTriggeredAt
+            ? submissions.filter((submittedAt) => submittedAt.getTime() <= hintTriggeredAt.getTime()).length
+            : null,
+          attemptsAfterHint: hintTriggeredAt
+            ? submissions.filter((submittedAt) => submittedAt.getTime() > hintTriggeredAt.getTime()).length
+            : null,
+          timeToSolveAfterHintSec:
+            hintTriggeredAt && solvedAt ? toSeconds(hintTriggeredAt, solvedAt) : null,
+        };
+      }),
+  );
+
+  return {
+    contestGroupRows,
+    problemStudentRows,
+  };
+}

--- a/src/server/instructorAnalysis/repository.ts
+++ b/src/server/instructorAnalysis/repository.ts
@@ -1,0 +1,370 @@
+import type { ExperimentGroup } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  SnapshotPreference,
+  SnapshotRunStatus,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+import { computeInstructorMetricsSnapshot } from "./metrics";
+
+type PrismaClient = typeof prisma;
+
+export interface InstructorAnalysisSnapshot {
+  instructor: {
+    id: string;
+    computingId: string;
+  };
+  contests: Array<{
+    id: string;
+    name: string;
+    status: "DRAFT" | "UPCOMING" | "ACTIVE" | "ENDED";
+    startsAt: Date;
+    endsAt: Date | null;
+    contestProblems: Array<{
+      problem: {
+        id: string;
+        code: string;
+        title: string;
+      };
+    }>;
+  }>;
+  selectedContestId: string | null;
+  selectedProblemId: string | null;
+  snapshot: {
+    requestedPreference: SnapshotPreference;
+    resolvedType: SnapshotType | null;
+    status: SnapshotRunStatus;
+    watermark: Date | null;
+    computedAt: Date | null;
+    message: string;
+  };
+  contestGroupRows: Array<{
+    groupName: ExperimentGroup;
+    solveRate: number;
+    meanSolveTimeSec: number | null;
+    medianSolveTimeSec: number | null;
+    attemptsToSolveMean: number | null;
+  }>;
+  problemStudentRows: Array<{
+    studentId: string;
+    studentName: string;
+    groupName: ExperimentGroup | null;
+    timeToFirstSubmissionSec: number | null;
+    timeToFirstCorrectSec: number | null;
+    postHintSolveProbability: number | null;
+    attemptsBeforeHint: number | null;
+    attemptsAfterHint: number | null;
+    timeToSolveAfterHintSec: number | null;
+  }>;
+}
+
+function resolveRequestedSnapshot(
+  endsAt: Date | null,
+  requestedPreference: SnapshotPreference,
+): {
+  resolvedType: SnapshotType | null;
+  watermark: Date | null;
+  message: string;
+} {
+  if (!endsAt) {
+    return {
+      resolvedType: null,
+      watermark: null,
+      message: "Snapshot scheduling starts once the contest has an end time.",
+    };
+  }
+
+  const preliminary = new Date(endsAt.getTime() + 5 * 60 * 1000);
+  const final = new Date(endsAt.getTime() + 15 * 60 * 1000);
+  const now = new Date();
+
+  if (requestedPreference === "preliminary") {
+    if (now.getTime() < preliminary.getTime()) {
+      return {
+        resolvedType: null,
+        watermark: preliminary,
+        message: "Preliminary snapshot becomes available 5 minutes after contest end.",
+      };
+    }
+
+    return {
+      resolvedType: "PRELIMINARY_5M",
+      watermark: preliminary,
+      message: "Showing the preliminary (+5m) snapshot.",
+    };
+  }
+
+  if (requestedPreference === "final") {
+    if (now.getTime() < final.getTime()) {
+      return {
+        resolvedType: null,
+        watermark: final,
+        message: "Final snapshot becomes available 15 minutes after contest end.",
+      };
+    }
+
+    return {
+      resolvedType: "FINAL_15M",
+      watermark: final,
+      message: "Showing the final (+15m) snapshot.",
+    };
+  }
+
+  if (now.getTime() >= final.getTime()) {
+    return {
+      resolvedType: "FINAL_15M",
+      watermark: final,
+      message: "Showing the latest available snapshot (final +15m).",
+    };
+  }
+
+  if (now.getTime() >= preliminary.getTime()) {
+    return {
+      resolvedType: "PRELIMINARY_5M",
+      watermark: preliminary,
+      message: "Showing the latest available snapshot (preliminary +5m).",
+    };
+  }
+
+  return {
+    resolvedType: null,
+    watermark: preliminary,
+    message: "No snapshot is ready yet. Preliminary metrics unlock 5 minutes after contest end.",
+  };
+}
+
+async function computeSnapshotRows(
+  client: PrismaClient,
+  contestId: string,
+  selectedProblemId: string | null,
+  snapshotType: SnapshotType,
+  watermark: Date,
+): Promise<{
+  contestGroupRows: InstructorAnalysisSnapshot["contestGroupRows"];
+  problemStudentRows: InstructorAnalysisSnapshot["problemStudentRows"];
+}> {
+  const contest = await client.contest.findUnique({
+    where: { id: contestId },
+    select: {
+      id: true,
+      startsAt: true,
+      contestProblems: {
+        orderBy: { ordering: "asc" },
+        select: {
+          problem: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+      experimentGroups: {
+        select: {
+          groupName: true,
+        },
+      },
+      participations: {
+        select: {
+          userId: true,
+          role: true,
+          experimentGroup: true,
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+      },
+      contestProblemSessions: {
+        select: {
+          userId: true,
+          problemId: true,
+          startedAt: true,
+          firstSubmitAt: true,
+          hintTriggeredAt: true,
+          solvedAt: true,
+          solved: true,
+        },
+      },
+      submissions: {
+        select: {
+          userId: true,
+          problemId: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!contest) {
+    return {
+      contestGroupRows: [],
+      problemStudentRows: [],
+    };
+  }
+
+  const computed = computeInstructorMetricsSnapshot(contest, snapshotType, watermark);
+
+  return {
+    contestGroupRows: computed.contestGroupRows.map((row) => ({
+      groupName: row.groupName,
+      solveRate: row.solveRate,
+      meanSolveTimeSec: row.meanSolveTimeSec,
+      medianSolveTimeSec: row.medianSolveTimeSec,
+      attemptsToSolveMean: row.attemptsToSolveMean,
+    })),
+    problemStudentRows: computed.problemStudentRows
+      .filter((row) => !selectedProblemId || row.problemId === selectedProblemId)
+      .map((row) => {
+        const participation = contest.participations.find(
+          (entry) => entry.userId === row.studentId,
+        );
+
+        if (!participation) {
+          return null;
+        }
+
+        return {
+          studentId: row.studentId,
+          studentName: `${participation.user.firstName} ${participation.user.lastName}`,
+          groupName: row.groupName,
+          timeToFirstSubmissionSec: row.timeToFirstSubmissionSec,
+          timeToFirstCorrectSec: row.timeToFirstCorrectSec,
+          postHintSolveProbability: row.postHintSolveProbability,
+          attemptsBeforeHint: row.attemptsBeforeHint,
+          attemptsAfterHint: row.attemptsAfterHint,
+          timeToSolveAfterHintSec: row.timeToSolveAfterHintSec,
+        };
+      })
+      .filter((row): row is InstructorAnalysisSnapshot["problemStudentRows"][number] => row !== null)
+      .sort((left, right) => {
+        if (left.groupName !== right.groupName) {
+          return (left.groupName ?? "").localeCompare(right.groupName ?? "");
+        }
+
+        return left.studentName.localeCompare(right.studentName);
+      }),
+  };
+}
+
+export async function loadInstructorAnalysisSnapshot(
+  client: PrismaClient,
+  computingId: string,
+  input: {
+    contestId?: string;
+    problemId?: string;
+    snapshotPreference: SnapshotPreference;
+  },
+): Promise<InstructorAnalysisSnapshot | null> {
+  const instructor = await client.user.findUnique({
+    where: { computingId },
+    select: {
+      id: true,
+      computingId: true,
+    },
+  });
+
+  if (!instructor) {
+    return null;
+  }
+
+  const contests = await client.contest.findMany({
+    where: { instructorId: instructor.id },
+    orderBy: [{ startsAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      startsAt: true,
+      endsAt: true,
+      contestProblems: {
+        orderBy: { ordering: "asc" },
+        select: {
+          problem: {
+            select: {
+              id: true,
+              code: true,
+              title: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (contests.length === 0) {
+    return {
+      instructor,
+      contests: [],
+      selectedContestId: null,
+      selectedProblemId: null,
+      snapshot: {
+        requestedPreference: input.snapshotPreference,
+        resolvedType: null,
+        status: "NOT_READY",
+        watermark: null,
+        computedAt: null,
+        message: "No instructor contests are available yet.",
+      },
+      contestGroupRows: [],
+      problemStudentRows: [],
+    };
+  }
+
+  const selectedContest = contests.find((contest) => contest.id === input.contestId) ?? contests[0];
+  const selectedContestId = selectedContest.id;
+  const selectedProblemId =
+    selectedContest.contestProblems.find((entry) => entry.problem.id === input.problemId)?.problem.id ??
+    selectedContest.contestProblems[0]?.problem.id ??
+    null;
+
+  const snapshotResolution = resolveRequestedSnapshot(
+    selectedContest.endsAt,
+    input.snapshotPreference,
+  );
+
+  let runStatus: SnapshotRunStatus = "NOT_READY";
+  let computedAt: Date | null = null;
+  let contestGroupRows: InstructorAnalysisSnapshot["contestGroupRows"] = [];
+  let problemStudentRows: InstructorAnalysisSnapshot["problemStudentRows"] = [];
+
+  if (snapshotResolution.resolvedType && snapshotResolution.watermark) {
+    try {
+      const computed = await computeSnapshotRows(
+        client,
+        selectedContestId,
+        selectedProblemId,
+        snapshotResolution.resolvedType,
+        snapshotResolution.watermark,
+      );
+      runStatus = "DONE";
+      computedAt = new Date();
+      contestGroupRows = computed.contestGroupRows;
+      problemStudentRows = computed.problemStudentRows;
+    } catch (error) {
+      runStatus = "FAILED";
+      snapshotResolution.message =
+        error instanceof Error
+          ? `Snapshot computation failed: ${error.message}`
+          : "Snapshot computation failed.";
+    }
+  }
+
+  return {
+    instructor,
+    contests,
+    selectedContestId,
+    selectedProblemId,
+    snapshot: {
+      requestedPreference: input.snapshotPreference,
+      resolvedType: snapshotResolution.resolvedType,
+      status: runStatus,
+      watermark: snapshotResolution.watermark,
+      computedAt,
+      message: snapshotResolution.message,
+    },
+    contestGroupRows,
+    problemStudentRows,
+  };
+}

--- a/src/server/instructorAnalysis/serializer.ts
+++ b/src/server/instructorAnalysis/serializer.ts
@@ -1,0 +1,80 @@
+import type {
+  InstructorAnalysisResponse,
+  SnapshotPreference,
+  SnapshotType,
+} from "@/lib/trpc/types/instructorAnalysis";
+import type { InstructorAnalysisSnapshot } from "./repository";
+
+function titleCaseContestStatus(
+  status: "DRAFT" | "UPCOMING" | "ACTIVE" | "ENDED",
+): "Draft" | "Upcoming" | "Active" | "Ended" {
+  switch (status) {
+    case "DRAFT":
+      return "Draft";
+    case "UPCOMING":
+      return "Upcoming";
+    case "ACTIVE":
+      return "Active";
+    case "ENDED":
+      return "Ended";
+  }
+}
+
+function snapshotPreferenceLabel(value: SnapshotPreference): string {
+  if (value === "latest") return "Latest Available";
+  if (value === "preliminary") return "Preliminary (+5m)";
+  return "Final (+15m)";
+}
+
+export function buildInstructorAnalysisResponse(
+  snapshot: InstructorAnalysisSnapshot,
+): InstructorAnalysisResponse {
+  const selectedContest =
+    snapshot.contests.find((contest) => contest.id === snapshot.selectedContestId) ?? null;
+
+  return {
+    role: "instructor",
+    filters: {
+      contests: snapshot.contests.map((contest) => ({
+        value: contest.id,
+        label: contest.name,
+      })),
+      problems: (selectedContest?.contestProblems ?? []).map((entry) => ({
+        value: entry.problem.id,
+        label: `${entry.problem.code} - ${entry.problem.title}`,
+      })),
+      snapshotPreferences: (["latest", "preliminary", "final"] as SnapshotPreference[]).map(
+        (value) => ({
+          value,
+          label: snapshotPreferenceLabel(value),
+        }),
+      ),
+    },
+    selection: {
+      contestId: snapshot.selectedContestId,
+      problemId: snapshot.selectedProblemId,
+      snapshotPreference: snapshot.snapshot.requestedPreference,
+    },
+    contest: {
+      id: selectedContest?.id ?? null,
+      title: selectedContest?.name ?? null,
+      startsAt: selectedContest?.startsAt.toISOString() ?? null,
+      endsAt: selectedContest?.endsAt?.toISOString() ?? null,
+      status: selectedContest ? titleCaseContestStatus(selectedContest.status) : null,
+    },
+    snapshot: {
+      requestedPreference: snapshot.snapshot.requestedPreference,
+      resolvedType: snapshot.snapshot.resolvedType as SnapshotType | null,
+      status: snapshot.snapshot.status,
+      watermark: snapshot.snapshot.watermark?.toISOString() ?? null,
+      computedAt: snapshot.snapshot.computedAt?.toISOString() ?? null,
+      message: snapshot.snapshot.message,
+    },
+    contestGroupMetrics: {
+      rows: snapshot.contestGroupRows,
+    },
+    problemStudentMetrics: {
+      rows: snapshot.problemStudentRows,
+    },
+  };
+}

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -2,6 +2,7 @@ import { router } from "../init";
 import { adminDashboardRouter } from "./adminDashboard";
 import { contestAuthoringRouter } from "./contestAuthoring";
 import { dashboardMetadataRouter } from "./dashboardMetadata";
+import { instructorAnalysisRouter } from "./instructorAnalysis";
 import { instructorManageContentRouter } from "./instructorManageContent";
 import { problemAuthoringRouter } from "./problemAuthoring";
 import { instructorDashboardRouter } from "./instructorDashboard";
@@ -14,6 +15,7 @@ export const appRouter = router({
   adminDashboard: adminDashboardRouter,
   dashboardMetadata: dashboardMetadataRouter,
   instructorDashboard: instructorDashboardRouter,
+  instructorAnalysis: instructorAnalysisRouter,
   contestAuthoring: contestAuthoringRouter,
   problemAuthoring: problemAuthoringRouter,
   instructorManageContent: instructorManageContentRouter,

--- a/src/server/trpc/routers/instructorAnalysis.ts
+++ b/src/server/trpc/routers/instructorAnalysis.ts
@@ -1,0 +1,32 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure, router } from "../init";
+import { loadInstructorAnalysisSnapshot } from "@/server/instructorAnalysis/repository";
+import { buildInstructorAnalysisResponse } from "@/server/instructorAnalysis/serializer";
+
+const instructorAnalysisInputSchema = z.object({
+  contestId: z.string().optional(),
+  problemId: z.string().optional(),
+  snapshotPreference: z.enum(["latest", "preliminary", "final"]).default("latest"),
+});
+
+export const instructorAnalysisRouter = router({
+  get: protectedProcedure
+    .input(instructorAnalysisInputSchema)
+    .query(async ({ ctx, input }) => {
+      if (ctx.user.role !== "instructor") {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
+
+      const snapshot = await loadInstructorAnalysisSnapshot(
+        ctx.prisma,
+        ctx.user.computingId,
+        input,
+      );
+      if (!snapshot) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Instructor not found" });
+      }
+
+      return buildInstructorAnalysisResponse(snapshot);
+    }),
+});


### PR DESCRIPTION
## Summary
Merge the completed instructor analysis work from `Spring-2026/students/sma382` into `main`. This includes the instructor-only analysis data pipeline, snapshot computation logic, tRPC access, and the research analytics UI for `/instructor/research-analytics`.

## Files Changed (<= 20)
- `src/lib/trpc/types/instructorAnalysis.ts`
- `src/lib/types/instructorAnalysis.ts`
- `src/server/instructorAnalysis/metrics.ts`
- `src/server/instructorAnalysis/repository.ts`
- `src/server/instructorAnalysis/serializer.ts`
- `src/server/trpc/routers/instructorAnalysis.ts`
- `src/server/trpc/routers/index.ts`
- `src/fe/instructor/services/instructorAnalysis.constants.ts`
- `src/fe/instructor/services/instructorAnalysis.mapper.ts`
- `src/fe/instructor/services/instructorAnalysis.ts`
- `src/fe/instructor/services/instructorAnalysis.export.ts`
- `src/fe/instructor/components/InstructorAnalysisSnapshotCard.tsx`
- `src/fe/instructor/components/InstructorAnalysisContestMetricsCard.tsx`
- `src/fe/instructor/components/InstructorAnalysisProblemMetricsCard.tsx`
- `src/fe/instructor/components/InstructorAnalysisExportActions.tsx`
- `src/fe/instructor/page/ResearchAnalyticsPage.tsx`
- `src/fe/instructor/styles/ResearchAnalyticsPage.module.css`

## Features Added
- Instructor-only research analytics data pipeline
- Snapshot preference support for latest, preliminary (+5m), and final (+15m) analysis views
- Contest group metrics table
- Problem student metrics table
- Export actions for analysis data
- Real-data research analytics page for `/instructor/research-analytics`

## APIs
- `GET /api/trpc/instructorAnalysis.get`

## UI Changes (screenshots, frontend only)
- Before: `/instructor/research-analytics` used the older mock-heavy analytics experience
- After: `/instructor/research-analytics` renders the real-data instructor analysis experience with snapshot status, contest metrics by group, problem metrics, and export actions

## QA
- Ran targeted `eslint` on the instructor analysis server and frontend files
- Ran `npx tsc --noEmit`; remaining failure is an existing unrelated baseline issue in `tests/e2e/practice/practice-python-ai-judging.spec.ts`
- Verified instructor dev login succeeds locally
- Verified `/instructor/research-analytics` returns `200`
- Verified `/instructor` still returns `200`
- Verified `/admin` still returns `200`
- Verified `/dashboard` still returns `200`
- Verified the research analytics page renders key sections including `Matrices Dashboard`, `Snapshot Status`, `Contest Metrics by Group`, and `Problem Metrics`
