### PR TITLE
fix harden auth flows

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated test artifacts:
+    "playwright-report/**",
+    "test-results/**",
   ]),
 ]);
 

--- a/src/app/(app)/practice/[id]/page.tsx
+++ b/src/app/(app)/practice/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { redirect } from "next/navigation";
 import PracticeProblemSubmissionPage from "@/fe/practice/page/PracticeProblemSubmissionPage";
+import { getCurrentUser } from "@/lib/session";
 
 interface PracticeProblemRouteProps {
   params: Promise<{ id: string }>;
@@ -7,6 +9,12 @@ interface PracticeProblemRouteProps {
 export const dynamic = "force-dynamic";
 
 export default async function PracticeProblemRoute({ params }: PracticeProblemRouteProps) {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   const { id } = await params;
-  return <PracticeProblemSubmissionPage problemCode={id} />;
+  return <PracticeProblemSubmissionPage problemCode={id} persistSubmissions={user.role === "student"} />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,8 +1,7 @@
-export default function SignupPage() {
-  return (
-    <div>
-      <h1>Signup Page</h1>
-      <p>TODO: Implement signup form</p>
-    </div>
-  );
+import SignupPage from "@/fe/auth/page/SignupPage";
+
+export default function SignupRoutePage() {
+  const showDevSignup = process.env.NEXT_PUBLIC_AUTH_MODE === "dev";
+
+  return <SignupPage showDevSignup={showDevSignup} />;
 }

--- a/src/app/api/auth/dev-signup/route.ts
+++ b/src/app/api/auth/dev-signup/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { handleDevSignup } from "@/server/api/auth/devSignup";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  return handleDevSignup(request);
+}

--- a/src/app/api/practice/submissions/route.ts
+++ b/src/app/api/practice/submissions/route.ts
@@ -3,6 +3,7 @@ import { getCurrentUser } from "@/lib/session";
 import {
   createPracticeSubmission,
   findDbUserIdByComputingId,
+  judgePracticeSubmissionEphemerally,
   parseSubmissionLanguage,
 } from "@/server/practice/submissionService";
 
@@ -14,13 +15,8 @@ export async function POST(request: NextRequest) {
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  if (user.role !== "student") {
+  if (user.role !== "student" && user.role !== "instructor") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const dbUserId = await findDbUserIdByComputingId(user.computingId);
-  if (!dbUserId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   let body: unknown;
@@ -53,6 +49,24 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    if (user.role === "instructor") {
+      const payload = await judgePracticeSubmissionEphemerally({
+        problemId,
+        language,
+        code,
+      });
+
+      return NextResponse.json({
+        ...payload,
+        persisted: false,
+      });
+    }
+
+    const dbUserId = await findDbUserIdByComputingId(user.computingId);
+    if (!dbUserId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const submission = await createPracticeSubmission({
       userId: dbUserId,
       problemId,
@@ -63,6 +77,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       submissionId: submission.id,
       status: "queued",
+      persisted: true,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to create submission";

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -9,9 +9,29 @@ export default function LogoutPage() {
   const router = useRouter();
 
   useEffect(() => {
-    // TODO: Clear auth tokens, session, etc.
-    // For now, just redirect to login
-    router.push("/login");
+    let cancelled = false;
+
+    const logout = async () => {
+      try {
+        await fetch("/api/auth/logout", {
+          method: "POST",
+          credentials: "include",
+        });
+      } catch {
+        // Ignore logout transport failures and continue navigation.
+      } finally {
+        if (!cancelled) {
+          router.replace("/login");
+          router.refresh();
+        }
+      }
+    };
+
+    void logout();
+
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   return (

--- a/src/fe/auth/page/SignupPage.tsx
+++ b/src/fe/auth/page/SignupPage.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import styles from "@/fe/auth/styles/LoginPage.module.css";
+
+interface SignupPageProps {
+  showDevSignup: boolean;
+}
+
+interface SignupFormState {
+  name: string;
+  computingId: string;
+  email: string;
+  studentNumber: string;
+}
+
+const INITIAL_FORM_STATE: SignupFormState = {
+  name: "",
+  computingId: "",
+  email: "",
+  studentNumber: "",
+};
+
+function validateForm(form: SignupFormState): string | null {
+  if (!form.name.trim()) {
+    return "Name is required.";
+  }
+
+  if (!form.computingId.trim()) {
+    return "Computing ID is required.";
+  }
+
+  if (!form.email.trim()) {
+    return "Email is required.";
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
+    return "Enter a valid email address.";
+  }
+
+  return null;
+}
+
+export default function SignupPage({ showDevSignup }: SignupPageProps) {
+  const router = useRouter();
+  const [form, setForm] = useState(INITIAL_FORM_STATE);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateField = (field: keyof SignupFormState, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!showDevSignup) {
+      return;
+    }
+
+    const validationError = validateForm(form);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/auth/dev-signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(form),
+      });
+
+      const payload = (await response.json().catch(() => null)) as { message?: string } | null;
+
+      if (!response.ok) {
+        setError(payload?.message ?? "Dev signup failed.");
+        return;
+      }
+
+      router.push("/dashboard");
+      router.refresh();
+    } catch {
+      setError("Dev signup failed.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.container}>
+        <div className={styles.brandIcon} aria-hidden>
+          {"</>"}
+        </div>
+        <h1 className={styles.brandTitle}>cs-coder</h1>
+        <p className={styles.brandSubtitle}>Competitive Programming Platform</p>
+
+        <article className={styles.card}>
+          <h2 className={styles.cardTitle}>Create Account</h2>
+          {showDevSignup ? (
+            <>
+              <p className={styles.cardDescription}>
+                DEV ONLY: Create a student account and sign in immediately.
+              </p>
+              <form className={styles.form} onSubmit={(event) => void handleSubmit(event)}>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>Name</span>
+                  <input
+                    className={styles.fieldInput}
+                    value={form.name}
+                    onChange={(event) => updateField("name", event.target.value)}
+                    autoComplete="name"
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>Computing ID</span>
+                  <input
+                    className={styles.fieldInput}
+                    value={form.computingId}
+                    onChange={(event) => updateField("computingId", event.target.value)}
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>Email</span>
+                  <input
+                    className={styles.fieldInput}
+                    type="email"
+                    value={form.email}
+                    onChange={(event) => updateField("email", event.target.value)}
+                    autoComplete="email"
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>Student Number (Optional)</span>
+                  <input
+                    className={styles.fieldInput}
+                    value={form.studentNumber}
+                    onChange={(event) => updateField("studentNumber", event.target.value)}
+                    autoComplete="off"
+                  />
+                </label>
+                <button type="submit" className={styles.casButton} disabled={isSubmitting}>
+                  {isSubmitting ? "Creating account..." : "Create Dev Account"}
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <p className={styles.cardDescription}>
+                Self-service signup is not enabled in this environment. Use the login page to sign
+                in through the configured authentication provider.
+              </p>
+              <Link href="/login" className={styles.secondaryLink}>
+                Back to Login
+              </Link>
+            </>
+          )}
+
+          {error ? (
+            <p role="alert" className={styles.errorText}>
+              {error}
+            </p>
+          ) : null}
+
+          <p className={styles.hint}>
+            Already have access?{" "}
+            <Link href="/login" className={styles.inlineLink}>
+              Sign in
+            </Link>
+          </p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/src/fe/auth/styles/LoginPage.module.css
+++ b/src/fe/auth/styles/LoginPage.module.css
@@ -179,6 +179,68 @@
   text-align: center;
 }
 
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.fieldInput {
+  height: 42px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0 12px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #0a0a0a;
+  background: #ffffff;
+}
+
+.fieldInput:focus {
+  outline: 2px solid rgba(220, 38, 38, 0.18);
+  outline-offset: 1px;
+  border-color: #dc2626;
+}
+
+.secondaryLink {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 42px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #111827;
+  font-size: 14px;
+  font-weight: 600;
+  background: #ffffff;
+}
+
+.inlineLink {
+  color: #b91c1c;
+  text-decoration: none;
+  font-weight: 600;
+}
+
 @media (max-width: 520px) {
   .brandTitle {
     font-size: 34px;
@@ -187,5 +249,9 @@
 
   .card {
     padding: 18px;
+  }
+
+  .formRow {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/fe/contests/data/problemDetails.ts
+++ b/src/fe/contests/data/problemDetails.ts
@@ -38,6 +38,8 @@ export interface SubmissionRecord {
     | "accepted"
     | "wrong"
     | "tle"
+    | "partial"
+    | "failed"
     | "runtime_error"
     | "system_error"
     | "compile_error";

--- a/src/fe/contests/page/ProblemSubmissionPage.tsx
+++ b/src/fe/contests/page/ProblemSubmissionPage.tsx
@@ -235,7 +235,7 @@ function ProblemSubmissionPageContent({
     return null;
   };
 
-  const submitContestCode = async (mode: "run" | "submit") => {
+  const submitContestCode = async () => {
     if (!hasCode || !detail.problemId) {
       return;
     }
@@ -277,12 +277,9 @@ function ProblemSubmissionPageContent({
           submissionId: payload.sid,
           status: "done",
           verdict: finalVerdict,
-          feedback:
-            mode === "run"
-              ? payload.message
-              : navigator?.nextHref
-                ? `${payload.message} You can use the navigator to continue to the next problem.`
-                : payload.message,
+          feedback: navigator?.nextHref
+            ? `${payload.message} You can use the navigator to continue to the next problem.`
+            : payload.message,
           errorMessage: null,
           testcases: [],
         }),
@@ -402,8 +399,7 @@ function ProblemSubmissionPageContent({
                 [effectiveLanguage]: nextCode,
               }));
             }}
-            onSubmitCode={() => void submitContestCode("submit")}
-            onSecondaryAction={() => void submitContestCode("run")}
+            onSubmitCode={() => void submitContestCode()}
             footerContent={
               submissionsLockedReason ? (
                 <Box px="20px" pb="4px">
@@ -413,8 +409,6 @@ function ProblemSubmissionPageContent({
                 </Box>
               ) : undefined
             }
-            secondaryButtonDisabled={!hasCode || isJudging || !detail.problemId || submissionsLocked}
-            secondaryButtonLabel={submitState === "submitting" ? "Submitting..." : "Run Code"}
             submitButtonDisabled={!hasCode || isJudging || !detail.problemId || submissionsLocked}
             submitButtonLabel={submitState === "submitting" ? "Submitting..." : "Submit"}
             submitButtonStartIcon={<SendRoundedIcon fontSize="small" />}

--- a/src/fe/practice/page/PracticeProblemSubmissionPage.tsx
+++ b/src/fe/practice/page/PracticeProblemSubmissionPage.tsx
@@ -23,6 +23,7 @@ import styles from "@/fe/contests/styles/ProblemSubmissionPage.module.css";
 
 interface PracticeProblemSubmissionPageProps {
   problemCode: string;
+  persistSubmissions?: boolean;
 }
 
 type SupportedLanguage = SupportedCodeLanguage;
@@ -84,12 +85,20 @@ function buildRunResult(input: {
 
 export default function PracticeProblemSubmissionPage({
   problemCode,
+  persistSubmissions = true,
 }: PracticeProblemSubmissionPageProps) {
-  return <PracticeProblemSubmissionPageContent key={problemCode} problemCode={problemCode} />;
+  return (
+    <PracticeProblemSubmissionPageContent
+      key={problemCode}
+      problemCode={problemCode}
+      persistSubmissions={persistSubmissions}
+    />
+  );
 }
 
 function PracticeProblemSubmissionPageContent({
   problemCode,
+  persistSubmissions = true,
 }: PracticeProblemSubmissionPageProps) {
   const router = useRouter();
   const [tab, setTab] = useState("description");
@@ -113,11 +122,11 @@ function PracticeProblemSubmissionPageContent({
 
   const { data: runHistory, refetch: refetchHistory } = trpc.practice.getRunHistory.useQuery(
     { problemCode },
-    { enabled: !!detail },
+    { enabled: !!detail && persistSubmissions },
   );
   const { data: latestRunRecord } = trpc.practice.getLatestRunRecord.useQuery(
     { problemCode },
-    { enabled: !!detail, retry: false },
+    { enabled: !!detail && persistSubmissions, retry: false },
   );
 
   const { mutateAsync: openSessionMutateAsync } = trpc.practiceExecution.openSession.useMutation();
@@ -242,13 +251,17 @@ function PracticeProblemSubmissionPageContent({
   }, [openSessionMutateAsync, problemCode, sessionInfo]);
 
   useEffect(() => {
+    if (!persistSubmissions) {
+      return;
+    }
+
     if (sessionOpened.current || pendingSessionRequest.current) {
       return;
     }
 
     sessionOpened.current = true;
     void ensureSessionInfo();
-  }, [ensureSessionInfo]);
+  }, [ensureSessionInfo, persistSubmissions]);
 
   useEffect(() => () => closeSubmissionStream(), [closeSubmissionStream]);
 
@@ -284,6 +297,7 @@ function PracticeProblemSubmissionPageContent({
 
   useEffect(() => {
     if (
+      !persistSubmissions ||
       !isDraftStorageReady ||
       hasPersistedDraft ||
       !latestRunRecord ||
@@ -320,18 +334,23 @@ function PracticeProblemSubmissionPageContent({
     isDraftStorageReady,
     latestRunRecord,
     openSubmissionStream,
+    persistSubmissions,
     runResult,
   ]);
 
   const handleSubmitCode = async () => {
-    if (!hasCode) return;
+    if (!hasCode || !detail) return;
 
-    const currentSession = await ensureSessionInfo();
+    const problemId = persistSubmissions
+      ? ((await ensureSessionInfo())?.problemId ?? detail.id)
+      : detail.id;
 
-    if (!currentSession) return;
+    if (!problemId) return;
 
     setHasRun(true);
-    setTab("submissions");
+    if (persistSubmissions) {
+      setTab("submissions");
+    }
     setSubmitState("submitting");
     setRunResult(null);
 
@@ -341,19 +360,35 @@ function PracticeProblemSubmissionPageContent({
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({
-          problemId: currentSession.problemId,
+          problemId,
           language: language === "cplusplus" ? "cpp" : language,
           code,
         }),
       });
 
       const payload = (await response.json()) as
-        | { submissionId: string; status: "queued" }
+        | ({ submissionId: string; status: "queued"; persisted?: true })
+        | (PracticeSubmissionPayload & { persisted: false })
         | { error?: string };
 
       if (!response.ok || !("submissionId" in payload)) {
         const errorMessage = "error" in payload ? payload.error : undefined;
         throw new Error(errorMessage ?? "Failed to create submission.");
+      }
+
+      if ("persisted" in payload && payload.persisted === false) {
+        setSubmitState(payload.status);
+        setRunResult(
+          buildRunResult({
+            submissionId: payload.submissionId,
+            status: payload.status,
+            verdict: payload.verdict,
+            feedback: payload.feedback,
+            errorMessage: payload.errorMessage,
+            testcases: payload.testcases,
+          }),
+        );
+        return;
       }
 
       setSubmitState("queued");
@@ -400,16 +435,25 @@ function PracticeProblemSubmissionPageContent({
   }
 
   const detailWithHistory = { ...detail, submissions: runHistory ?? [] };
+  const persistenceNote = !persistSubmissions ? (
+    <Box px="20px" pb="4px">
+      <Typography variant="body2" color="text.secondary">
+        Instructor AI reviews are temporary and are not saved to submission history.
+      </Typography>
+    </Box>
+  ) : undefined;
 
   const outputSection = hasRun ? (
     <div className={styles.outputSection}>
-      <Typography className={styles.outputTitle}>Output</Typography>
+      <Typography className={styles.outputTitle}>AI Feedback</Typography>
       <div className={styles.outputBlock}>
         {isJudging || displayedRunResult?.status === "queued" || displayedRunResult?.status === "running" ? (
           <Box display="flex" alignItems="center" gap="10px">
             <CircularProgress size={14} sx={{ color: "#f3f4f6" }} />
             <span className={styles.outputText}>
-              {submitState === "queued" ? "Queued for Gemini judging..." : "Judging your code..."}
+              {submitState === "queued"
+                ? "Queued for AI review..."
+                : "Reviewing your code with AI..."}
             </span>
           </Box>
         ) : (
@@ -418,7 +462,7 @@ function PracticeProblemSubmissionPageContent({
               {displayedRunResult?.feedback ??
                 displayedRunResult?.errorMessage ??
                 displayedRunResult?.verdict ??
-                "Code executed (no output)"}
+                "No AI feedback returned."}
             </span>
             {displayedRunResult && displayedRunResult.testcases.length > 0 ? (
               <Box display="flex" flexDirection="column" gap="6px">
@@ -471,6 +515,7 @@ function PracticeProblemSubmissionPageContent({
               }))
             }
             onSubmitCode={handleSubmitCode}
+            footerContent={persistenceNote}
             submitButtonDisabled={!hasCode || isJudging}
             submitButtonLabel={isSubmitting ? "Submitting..." : isJudging ? "Judging..." : "Submit"}
           />

--- a/src/fe/shared/constants/options.ts
+++ b/src/fe/shared/constants/options.ts
@@ -72,6 +72,16 @@ export const SUBMISSION_STATUS_CONFIG = {
     color: "#e7000b",
     icon: CancelOutlinedIcon,
   },
+  partial: {
+    label: "Partial",
+    color: "#f59e0b",
+    icon: AccessTimeOutlinedIcon,
+  },
+  failed: {
+    label: "Failed",
+    color: "#e7000b",
+    icon: CancelOutlinedIcon,
+  },
   tle: {
     label: "Time Limit Exceeded",
     color: "#f54900",

--- a/src/server/api/auth/devSignup.ts
+++ b/src/server/api/auth/devSignup.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createDevSessionToken } from "@/lib/devAuthSession";
+import { prisma } from "@/lib/prisma";
+import { recordDailyLogin, syncStudentGamification } from "@/server/gamification/persistence";
+
+const DEV_SESSION_TTL_SECONDS = 60 * 60 * 6;
+const SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME || "session";
+
+function isDevAuthEnabled(): boolean {
+  return process.env.AUTH_MODE === "dev";
+}
+
+const devSignupSchema = z.object({
+  name: z.string().trim().min(1, "Name is required."),
+  computingId: z.string().trim().min(1, "Computing ID is required."),
+  email: z.string().trim().email("Enter a valid email address."),
+  studentNumber: z.string().trim().optional().default(""),
+});
+
+function splitName(value: string): { firstName: string; lastName: string } {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  const firstName = parts[0] ?? "Student";
+  const lastName = parts.slice(1).join(" ") || firstName;
+  return { firstName, lastName };
+}
+
+export async function handleDevSignup(request: NextRequest): Promise<NextResponse> {
+  if (!isDevAuthEnabled()) {
+    return NextResponse.json(
+      { message: "Dev signup is disabled outside dev mode." },
+      { status: 403 },
+    );
+  }
+
+  const secret = process.env.DEV_AUTH_COOKIE_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { message: "DEV_AUTH_COOKIE_SECRET is required for dev signup." },
+      { status: 500 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: "Invalid request body." }, { status: 400 });
+  }
+
+  const parsed = devSignupSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: parsed.error.issues[0]?.message ?? "Invalid signup data." },
+      { status: 400 },
+    );
+  }
+
+  const name = parsed.data.name;
+  const computingId = parsed.data.computingId.toLowerCase();
+  const email = parsed.data.email.toLowerCase();
+  const studentNumber = parsed.data.studentNumber;
+  const { firstName, lastName } = splitName(name);
+
+  const existingUser = await prisma.user.findFirst({
+    where: {
+      OR: [{ computingId }, { email }],
+    },
+    select: {
+      computingId: true,
+      email: true,
+    },
+  });
+
+  if (existingUser) {
+    return NextResponse.json(
+      {
+        message:
+          existingUser.computingId === computingId
+            ? "That computing ID is already in use."
+            : "That email is already in use.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const user = await prisma.user.create({
+    data: {
+      firstName,
+      lastName,
+      computingId,
+      email,
+      studentNumber: studentNumber || null,
+      role: "STUDENT",
+    },
+    select: {
+      id: true,
+      computingId: true,
+      email: true,
+    },
+  });
+
+  await recordDailyLogin(user.id);
+  await syncStudentGamification(user.computingId);
+
+  const { token } = createDevSessionToken(
+    {
+      computingId: user.computingId,
+      email: user.email,
+      role: "student",
+      ttlSeconds: DEV_SESSION_TTL_SECONDS,
+    },
+    secret,
+  );
+
+  const response = NextResponse.json(
+    {
+      message: "Dev signup successful.",
+      user: {
+        computingId: user.computingId,
+        email: user.email,
+        role: "student",
+      },
+      expiresInSeconds: DEV_SESSION_TTL_SECONDS,
+    },
+    { status: 201 },
+  );
+
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: DEV_SESSION_TTL_SECONDS,
+  });
+
+  return response;
+}

--- a/src/server/api/s/hint.ts
+++ b/src/server/api/s/hint.ts
@@ -39,10 +39,13 @@ export async function handleRequestHint(request: NextRequest) {
 
     const data = await response.json();
     return NextResponse.json(data);
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to generate hint", details: error.message },
+      {
+        error: "Failed to generate hint",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
       { status: 500 }
     );
   }
@@ -56,20 +59,22 @@ export async function handleGetHints(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const computing_id = searchParams.get("computing_id") || user.computingId;
     const pid = searchParams.get("pid");
 
     if (!pid) {
       return NextResponse.json({ error: "Missing pid" }, { status: 400 });
     }
 
-    const hints = await dbHelpers.getAllHints(computing_id, pid);
+    const hints = await dbHelpers.getAllHints(user.computingId, pid);
 
     return NextResponse.json({ hints });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(error);
     return NextResponse.json(
-      { error: "Could not retrieve hints", details: error.message },
+      {
+        error: "Could not retrieve hints",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
       { status: 500 }
     );
   }

--- a/src/server/api/s/profile.ts
+++ b/src/server/api/s/profile.ts
@@ -39,10 +39,13 @@ export async function handleUpdateProfile(request: NextRequest) {
     const updatedUser = await dbHelpers.findUserByComputingId(user.computingId);
 
     return NextResponse.json({ message: "Profile updated", user: updatedUser });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to update profile", details: error.message },
+      {
+        error: "Failed to update profile",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
       { status: 400 }
     );
   }

--- a/src/server/practice/submissionService.ts
+++ b/src/server/practice/submissionService.ts
@@ -221,6 +221,56 @@ export async function createPracticeSubmission(args: {
   return record;
 }
 
+export async function judgePracticeSubmissionEphemerally(args: {
+  problemId: string;
+  language: AppLanguage;
+  code: string;
+}): Promise<PracticeSubmissionPayload> {
+  const problem = await getPracticeProblemById(args.problemId);
+  if (!problem) {
+    throw new Error("Problem not found.");
+  }
+
+  const provider = getJudgingProvider();
+  const startedAt = Date.now();
+  const submissionId = `ephemeral-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+  logInfo("ephemeral submission started", {
+    submissionId,
+    problemId: args.problemId,
+    language: args.language,
+  });
+
+  const result = await provider.judgeSubmission({
+    submissionId,
+    language: args.language === "cplusplus" ? "cpp" : args.language,
+    code: args.code,
+    problem,
+    visibleTests: buildVisibleTests(problem),
+  });
+
+  logInfo("ephemeral submission done", {
+    submissionId,
+    problemId: args.problemId,
+    language: args.language,
+    verdict: result.verdict,
+    score: result.score,
+    latencyMs: Date.now() - startedAt,
+  });
+
+  return {
+    submissionId,
+    status: "done",
+    score: result.score,
+    verdict: result.verdict,
+    feedback: result.feedback,
+    testcases: result.testcases,
+    judgedBy: provider.name,
+    updatedAt: new Date().toISOString(),
+    errorMessage: null,
+  };
+}
+
 async function runPracticeSubmissionJudging(args: {
   submissionId: string;
   problem: PracticeProblemRecord;

--- a/src/server/trpc/routers/practice.ts
+++ b/src/server/trpc/routers/practice.ts
@@ -56,10 +56,24 @@ function formatTimeAgo(date: Date): string {
   return `${days} day${days !== 1 ? "s" : ""} ago`;
 }
 
-function mapRunVerdictToStatus(verdict: string): "accepted" | "wrong" | "tle" {
-  if (verdict === "Accepted") return "accepted";
-  if (verdict === "Time Limit Exceeded") return "tle";
-  return "wrong";
+function mapRunVerdictToStatus(
+  verdict: string,
+): "accepted" | "wrong" | "tle" | "partial" | "failed" | "runtime_error" {
+  switch (verdict.trim().toLowerCase()) {
+    case "accepted":
+      return "accepted";
+    case "time limit exceeded":
+      return "tle";
+    case "partial":
+      return "partial";
+    case "runtime error":
+      return "runtime_error";
+    case "failed":
+      return "failed";
+    case "wrong answer":
+    default:
+      return "wrong";
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +197,7 @@ export const practiceRouter = router({
         ) as Partial<Record<(typeof APP_LANGUAGES)[number], string>>,
         submissions: [] as {
           id: string;
-          status: "accepted" | "wrong" | "tle";
+          status: "accepted" | "wrong" | "tle" | "partial" | "failed" | "runtime_error";
           language: string;
           runtime: string;
           memory: string;


### PR DESCRIPTION
## Summary
- This MR cleans up contest and practice submission UX, adds a low-risk dev-only signup flow, hardens student auth endpoints, and improves lint signal by excluding generated Playwright artifacts.

## Files Changed
- `eslint.config.mjs`
- `src/app/(app)/practice/[id]/page.tsx`
- `src/app/(auth)/signup/page.tsx`
- `src/app/api/auth/dev-signup/route.ts`
- `src/app/api/practice/submissions/route.ts`
- `src/app/logout/page.tsx`
- `src/fe/auth/page/SignupPage.tsx`
- `src/fe/auth/styles/LoginPage.module.css`
- `src/fe/contests/data/problemDetails.ts`
- `src/fe/contests/page/ProblemSubmissionPage.tsx`
- `src/fe/practice/page/PracticeProblemSubmissionPage.tsx`
- `src/fe/shared/constants/options.ts`
- `src/server/api/auth/devSignup.ts`
- `src/server/api/s/hint.ts`
- `src/server/api/s/profile.ts`
- `src/server/practice/submissionService.ts`
- `src/server/trpc/routers/practice.ts`

## Features Added
- Added a dev-only signup flow that creates a student account and signs the user in immediately.
- Added instructor-only ephemeral practice reviews with no persistence to `PracticeSession` or `PracticeRunRecord`.
- Added basic signup validation for `name`, `computingId`, `email`, and `studentNumber`.
- Added new submission status support for `partial` and `failed` in shared UI status handling.

## Components
- `SignupPage`
- `PracticeProblemSubmissionPage`
- `ProblemSubmissionPage`

## Data
- No Prisma schema changes were introduced.
- Dev signup maps a single `name` input into the existing `firstName` and `lastName` user fields.
- Instructor practice reviews now return AI feedback without creating persistent practice session or run records.

## Data & Utilities
- `devSignupSchema`
- `splitName`
- Updated practice verdict-to-history status mapping in `src/server/trpc/routers/practice.ts`
- Updated ESLint global ignores for generated Playwright output

## Styles
- `src/fe/auth/styles/LoginPage.module.css`

## APIs
- Added `POST /api/auth/dev-signup` for dev-mode student account creation and immediate sign-in.
- Updated `POST /api/practice/submissions` to support non-persistent instructor practice reviews.
- Updated `GET /api/s/hints` to use the authenticated user only and ignore caller-provided `computing_id`.
- Updated `/logout` page flow to call the existing logout API before redirecting.

## QA
- Targeted lint passed for touched auth, hint, logout, practice, and profile files.
- Full `npm run lint` no longer scans generated `playwright-report/**` and `test-results/**` artifacts.
