### PR TITLE
feat: add dashboard contest confirmation flow

### DIFF
--- a/src/fe/dashboard/components/ContestAlert.tsx
+++ b/src/fe/dashboard/components/ContestAlert.tsx
@@ -8,15 +8,17 @@ interface ContestAlertProps {
   title: string;
   description: string;
   onJoin?: () => void;
+  buttonLabel?: string;
 }
 
 export default function ContestAlert({
   title,
   description,
   onJoin,
+  buttonLabel = "Join Now",
 }: ContestAlertProps) {
   return (
-    <div className={styles.alert}>
+    <div className={styles.alert} data-testid="contest-alert">
       <div className={styles.content}>
         <div className={styles.iconWrapper}>
           <EmojiEventsOutlinedIcon className={styles.icon} />
@@ -26,8 +28,8 @@ export default function ContestAlert({
           <div className={styles.description}>{description}</div>
         </div>
       </div>
-      <button className={styles.button} onClick={onJoin}>
-        Join Now
+      <button className={styles.button} onClick={onJoin} data-testid="contest-alert-action">
+        {buttonLabel}
         <ArrowForwardIcon className={styles.arrowIcon} />
       </button>
     </div>

--- a/src/fe/dashboard/components/PastContests.tsx
+++ b/src/fe/dashboard/components/PastContests.tsx
@@ -1,18 +1,47 @@
 "use client";
 
-import ContestResultCard from "./ContestResultCard";
+import type { KeyboardEvent } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
+import ContestResultCard from "./ContestResultCard";
 import { buildContestRoute } from "@/fe/shared/constants/routes";
 import type { DashboardContestHistoryItem } from "@/fe/dashboard/services/dashboardContests";
 import styles from "../styles/PastContests.module.css";
 
 interface PastContestsProps {
   contests?: DashboardContestHistoryItem[];
+  emptyMessage?: string;
+  onContestEntry?: (contestId: string) => void;
 }
 
-export default function PastContests({ contests = [] }: PastContestsProps) {
+export default function PastContests({
+  contests = [],
+  emptyMessage = "No contest activity yet.",
+  onContestEntry,
+}: PastContestsProps) {
+  const router = useRouter();
+
+  function handleContestOpen(contest: DashboardContestHistoryItem): void {
+    if (contest.actionLabel) {
+      onContestEntry?.(contest.id);
+      return;
+    }
+
+    router.push(buildContestRoute(contest.id));
+  }
+
+  function handleCardKeyDown(
+    event: KeyboardEvent<HTMLDivElement>,
+    contest: DashboardContestHistoryItem,
+  ): void {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleContestOpen(contest);
+    }
+  }
+
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="my-contests">
       <div className={styles.header}>
         <h2 className={styles.title}>My Contests</h2>
         <Link href="/contests" className={styles.viewAll}>
@@ -20,15 +49,19 @@ export default function PastContests({ contests = [] }: PastContestsProps) {
         </Link>
       </div>
       {contests.length === 0 ? (
-        <div className={styles.empty}>No contest activity yet.</div>
+        <div className={styles.empty}>{emptyMessage}</div>
       ) : (
         <div className={styles.list}>
           {contests.map((contest) => (
-            <Link
+            <div
               key={contest.id}
-              href={buildContestRoute(contest.id)}
               className={styles.cardLink}
               aria-label={`Open contest ${contest.title}`}
+              data-testid={`my-contest-${contest.id}`}
+              role="link"
+              tabIndex={0}
+              onClick={() => handleContestOpen(contest)}
+              onKeyDown={(event) => handleCardKeyDown(event, contest)}
             >
               <ContestResultCard
                 title={contest.title}
@@ -36,7 +69,7 @@ export default function PastContests({ contests = [] }: PastContestsProps) {
                 participants={contest.participants}
                 status={contest.status}
               />
-            </Link>
+            </div>
           ))}
         </div>
       )}

--- a/src/fe/dashboard/components/UpcomingContests.tsx
+++ b/src/fe/dashboard/components/UpcomingContests.tsx
@@ -11,6 +11,7 @@ interface UpcomingContestsProps {
   title?: string;
   emptyMessage?: string;
   hideCourseCode?: boolean;
+  onContestAction?: (contest: UpcomingContest) => void;
 }
 
 export default function UpcomingContests({
@@ -18,13 +19,14 @@ export default function UpcomingContests({
   title = "Upcoming Contests",
   emptyMessage = "No upcoming contests right now.",
   hideCourseCode = false,
+  onContestAction,
 }: UpcomingContestsProps) {
   return (
     <DashboardWidget title={title} icon={AccessTimeIcon}>
       <div className={styles.list}>
         {contests.length === 0 && <div className={styles.emptyState}>{emptyMessage}</div>}
         {contests.map((contest) => (
-          <article key={contest.id} className={styles.contestCard}>
+          <article key={contest.id} className={styles.contestCard} data-testid={`upcoming-contest-${contest.id}`}>
             <div className={styles.contestHeader}>
               <div className={styles.contestHeaderText}>
                 <div className={styles.contestTitle}>{contest.title}</div>
@@ -43,6 +45,20 @@ export default function UpcomingContests({
             </div>
             <div className={styles.date}>{contest.date}</div>
             <div className={styles.timeUntil}>{contest.timeUntil}</div>
+            {contest.actionLabel ? (
+              <div className={styles.actionRow}>
+                <button
+                  type="button"
+                  className={styles.actionButton}
+                  data-testid="upcoming-contest-action"
+                  disabled={contest.actionLabel === "Registered"}
+                  data-variant={contest.actionLabel === "Register" ? "secondary" : "primary"}
+                  onClick={() => onContestAction?.(contest)}
+                >
+                  {contest.actionLabel}
+                </button>
+              </div>
+            ) : null}
           </article>
         ))}
       </div>

--- a/src/fe/dashboard/page/DashboardPage.tsx
+++ b/src/fe/dashboard/page/DashboardPage.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import ScrollbarHider from "@/fe/shared/components/ui/ScrollbarHider";
 import StatisticsSection from "@/fe/dashboard/components/StatisticsSection";
 import ContestAlert from "@/fe/dashboard/components/ContestAlert";
@@ -14,17 +20,93 @@ import {
 } from "@/fe/dashboard/services/dashboardMetadata";
 import type { StudentDashboardContestSummary } from "@/fe/dashboard/services/dashboardContests";
 import { buildContestRoute } from "@/fe/shared/constants/routes";
+import type { UpcomingContest } from "@/fe/shared/types/contest";
 import styles from "../styles/DashboardPage.module.css";
 
 interface DashboardPageProps {
   contestSummary?: StudentDashboardContestSummary;
 }
 
+type PendingAction = "register" | "enter";
+
 export default function DashboardPage({ contestSummary }: DashboardPageProps) {
   const router = useRouter();
   const { metadata, isLoading, isError } = useStudentDashboardMetadata();
   const resolvedMetadata = metadata ?? EMPTY_STUDENT_DASHBOARD_METADATA;
   const alert = !isLoading ? contestSummary?.alert ?? null : null;
+  const [pendingContestId, setPendingContestId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const pendingContest = useMemo(() => {
+    if (!pendingContestId || !contestSummary) {
+      return null;
+    }
+
+    return (
+      contestSummary.recentContests.find((contest) => contest.id === pendingContestId) ??
+      contestSummary.upcomingContests.find((contest) => contest.id === pendingContestId) ??
+      (contestSummary.alert?.contestId === pendingContestId
+        ? {
+            id: contestSummary.alert.contestId,
+            title: contestSummary.alert.title,
+            actionLabel: contestSummary.alert.actionLabel,
+          }
+        : null)
+    );
+  }, [contestSummary, pendingContestId]);
+
+  function openContestConfirmation(contestId: string, action: PendingAction): void {
+    setPendingContestId(contestId);
+    setPendingAction(action);
+    setActionError(null);
+  }
+
+  function handlePastContestEntry(contestId: string): void {
+    openContestConfirmation(contestId, "enter");
+  }
+
+  function handleUpcomingContestAction(contest: UpcomingContest): void {
+    if (contest.actionLabel === "Registered") {
+      return;
+    }
+
+    openContestConfirmation(contest.id, contest.actionLabel === "Register" ? "register" : "enter");
+  }
+
+  function closeContestConfirmation(): void {
+    setPendingContestId(null);
+    setPendingAction(null);
+    setActionError(null);
+  }
+
+  async function confirmContestEntry(): Promise<void> {
+    if (!pendingContestId || !pendingAction) {
+      return;
+    }
+
+    setActionError(null);
+
+    if (pendingAction === "register") {
+      const response = await fetch(`/api/s/contest/register/${pendingContestId}`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        setActionError(payload?.error ?? "Unable to register for this contest right now.");
+        return;
+      }
+
+      closeContestConfirmation();
+      router.refresh();
+      return;
+    }
+
+    closeContestConfirmation();
+    router.push(buildContestRoute(pendingContestId));
+  }
 
   return (
     <>
@@ -36,6 +118,7 @@ export default function DashboardPage({ contestSummary }: DashboardPageProps) {
               Unable to load student dashboard metadata right now.
             </div>
           )}
+          {actionError ? <div className={styles.errorBanner}>{actionError}</div> : null}
 
           <StatisticsSection stats={resolvedMetadata.statistics} />
 
@@ -43,19 +126,48 @@ export default function DashboardPage({ contestSummary }: DashboardPageProps) {
             <ContestAlert
               title={alert.title}
               description={alert.description}
-              onJoin={() => router.push(buildContestRoute(alert.contestId))}
+              buttonLabel={alert.actionLabel}
+              onJoin={() => openContestConfirmation(alert.contestId, "enter")}
             />
           )}
 
-          <PastContests contests={contestSummary?.recentContests ?? []} />
+          <PastContests
+            contests={contestSummary?.recentContests ?? []}
+            onContestEntry={handlePastContestEntry}
+          />
         </div>
 
         <div className={styles.sidebar}>
-          <UpcomingContests contests={contestSummary?.upcomingContests ?? []} />
+          <UpcomingContests
+            contests={contestSummary?.upcomingContests ?? []}
+            onContestAction={handleUpcomingContestAction}
+          />
           <ThisWeek stats={resolvedMetadata.weeklyStats} />
           <RecentBadges badges={resolvedMetadata.badges} />
         </div>
       </div>
+
+      <Dialog open={pendingContest !== null} onClose={closeContestConfirmation} maxWidth="xs" fullWidth>
+        <DialogTitle>Confirm Contest Entry</DialogTitle>
+        <DialogContent>
+          {pendingContest
+            ? pendingAction === "register"
+              ? `You're about to register for ${pendingContest.title}. Please confirm before continuing.`
+              : `You're about to ${
+                  pendingContest.actionLabel === "Attend Contest" ? "enter" : "rejoin"
+                } ${pendingContest.title}. Please confirm before continuing.`
+            : "Please confirm before continuing."}
+          {actionError ? <div className={styles.errorBanner}>{actionError}</div> : null}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeContestConfirmation} color="inherit">
+            Cancel
+          </Button>
+          <Button onClick={() => void confirmContestEntry()} variant="contained" color="warning">
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/src/fe/dashboard/services/dashboardContests.ts
+++ b/src/fe/dashboard/services/dashboardContests.ts
@@ -11,12 +11,13 @@ export interface DashboardContestHistoryItem {
   date: string;
   participants: number;
   status: ContestStatus;
+  actionLabel?: "Attend Contest" | "Join Now";
 }
 
 export interface StudentDashboardContestSummary {
   upcomingContests: UpcomingContest[];
   recentContests: DashboardContestHistoryItem[];
-  alert: (DashboardContestAlert & { contestId: string }) | null;
+  alert: (DashboardContestAlert & { contestId: string; actionLabel: "Join Now" }) | null;
 }
 
 function toTimestamp(value: string) {
@@ -117,13 +118,22 @@ export function mapStudentDashboardContests(
   const upcomingContests = visibleContests
     .filter((contest) => contest.status === "UPCOMING" || contest.status === "ACTIVE")
     .slice(0, 3)
-    .map((contest) => ({
-      id: contest.id,
-      title: contest.name,
-      date: formatContestDate(contest.startsAt),
-      timeUntil: formatTimeUntil(contest),
-      readinessState: contest.status === "ACTIVE" ? "Ready" : undefined,
-    })) satisfies UpcomingContest[];
+    .map((contest) => {
+      const isParticipating = myContests.some((registeredContest) => registeredContest.id === contest.id);
+
+      return {
+        id: contest.id,
+        title: contest.name,
+        date: formatContestDate(contest.startsAt),
+        timeUntil: formatTimeUntil(contest),
+        readinessState: contest.status === "ACTIVE" ? "Ready" : undefined,
+        actionLabel: isParticipating
+          ? contest.status === "ACTIVE"
+            ? "Join Now"
+            : "Registered"
+          : "Register",
+      };
+    }) satisfies UpcomingContest[];
 
   const recentContests = myContests.slice(0, 3).map((contest) => ({
     id: contest.id,
@@ -131,7 +141,13 @@ export function mapStudentDashboardContests(
     date: formatContestDate(contest.startsAt),
     participants: contest.participants,
     status: mapContestStatus(contest.status),
-  }));
+    actionLabel:
+      contest.status === "ACTIVE"
+        ? "Join Now"
+        : contest.status === "UPCOMING"
+          ? "Attend Contest"
+          : undefined,
+  })) satisfies DashboardContestHistoryItem[];
 
   const highlightedContest =
     visibleContests.find((contest) => contest.status === "ACTIVE") ?? null;
@@ -140,15 +156,14 @@ export function mapStudentDashboardContests(
     upcomingContests,
     recentContests,
     alert: highlightedContest
-      ? {
+        ? {
           contestId: highlightedContest.id,
           title: "Contest in Progress!",
           description: `${highlightedContest.name} is currently active.`,
           isActive: true,
+          actionLabel: "Join Now",
         }
       : null,
   };
 }
-
-
 

--- a/src/fe/dashboard/services/dashboardContests.ts
+++ b/src/fe/dashboard/services/dashboardContests.ts
@@ -150,7 +150,7 @@ export function mapStudentDashboardContests(
   })) satisfies DashboardContestHistoryItem[];
 
   const highlightedContest =
-    visibleContests.find((contest) => contest.status === "ACTIVE") ?? null;
+    myContests.find((contest) => contest.status === "ACTIVE") ?? null;
 
   return {
     upcomingContests,
@@ -166,4 +166,3 @@ export function mapStudentDashboardContests(
       : null,
   };
 }
-

--- a/src/fe/dashboard/styles/UpcomingContests.module.css
+++ b/src/fe/dashboard/styles/UpcomingContests.module.css
@@ -61,6 +61,44 @@
   margin-top: 8px;
 }
 
+.actionRow {
+  margin-top: 12px;
+}
+
+.actionButton {
+  width: 100%;
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-family: Inter, sans-serif;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.actionButton[data-variant="primary"] {
+  background: #c2410c;
+  color: #ffffff;
+}
+
+.actionButton[data-variant="secondary"] {
+  background: #fff7ed;
+  color: #c2410c;
+  border: 1px solid #fdba74;
+}
+
+.actionButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.actionButton:not(:disabled):hover {
+  opacity: 0.92;
+  transform: translateY(-1px);
+}
+
 .readinessChip {
   border-radius: 999px;
   padding: 2px 8px;

--- a/src/fe/shared/types/contest.ts
+++ b/src/fe/shared/types/contest.ts
@@ -22,12 +22,15 @@ export interface UpcomingContest {
   date: string;
   timeUntil: string;
   readinessState?: "Ready" | "Needs Attention" | "Blocked";
+  actionLabel?: "Register" | "Registered" | "Join Now";
 }
 
 export interface ContestAlert {
   title: string;
   description: string;
   isActive: boolean;
+  contestId?: string;
+  actionLabel?: "Join Now";
 }
 
 export interface ContestsResponse {


### PR DESCRIPTION
## Summary
Add a confirmation flow for student dashboard contest actions. This PR adds confirm-before-continue behavior for dashboard contest entry and registration actions, updates upcoming contest cards with explicit action states, and ensures the dashboard contest alert only appears for contests the student has already registered for.

## Files Changed (<= 20)
- `src/fe/dashboard/page/DashboardPage.tsx`
- `src/fe/dashboard/components/PastContests.tsx`
- `src/fe/dashboard/components/UpcomingContests.tsx`
- `src/fe/dashboard/components/ContestAlert.tsx`
- `src/fe/dashboard/services/dashboardContests.ts`
- `src/fe/shared/types/contest.ts`
- `src/fe/dashboard/styles/UpcomingContests.module.css`

## Features Added
- Confirm-before-continue dialog for dashboard contest registration and entry actions
- Action buttons on upcoming contest cards with `Register`, `Registered`, and `Join Now` states
- Confirmed contest-entry flow from `My Contests` for active or upcoming registered contests
- Dashboard contest alert restricted to active contests the student has already registered for

## Components
- `DashboardPage`
- `PastContests`
- `UpcomingContests`
- `ContestAlert`

## Data
- Extend shared contest view types with dashboard action labels and alert metadata

## Data & Utilities
- Update dashboard contest mapping so `My Contests` preserves registered contests only while upcoming cards expose explicit action states
- No backend API or database changes in this PR

## Styles
- `src/fe/dashboard/styles/UpcomingContests.module.css`

## UI Changes (screenshots, frontend only)
- Before: dashboard contest actions navigated immediately and upcoming cards had no explicit registration/entry controls
- After: dashboard contest actions open a confirmation dialog first, upcoming cards show action buttons, and the dashboard alert only appears for registered active contests

## QA
- Ran targeted `eslint` on the updated student dashboard files
- Ran `npx tsc --noEmit`; remaining failure is an existing unrelated baseline issue in `tests/e2e/practice/practice-python-ai-judging.spec.ts`
- Verified the change is limited to the intended student dashboard frontend files
- Confirmed `My Contests` still derives from registered/participated contests only
- Confirmed the dashboard alert is now limited to active contests the student is already registered for
